### PR TITLE
Fix word break in profile user name

### DIFF
--- a/frontend/html/users/widgets/card.html
+++ b/frontend/html/users/widgets/card.html
@@ -5,7 +5,8 @@
     </div>
     <div class="profile-card-info">
         <a href="{% url "profile" user.slug %}" class="profile-user-name">
-            {{ user.full_name }} <span class="profile-user-nickname">@{{ user.slug }}</span>
+            <span class="profile-user-fullname">{{ user.full_name }}</span>
+            <span class="profile-user-nickname">@{{ user.slug }}</span>
         </a>
 
         {% if user.position or user.company %}

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -458,13 +458,16 @@
             font-weight: 600;
             padding-bottom: 10px;
             text-decoration: none;
+            word-break: break-word;
         }
 
+            .profile-user-fullname {
+                margin-right: 15px;
+            }
             .profile-user-nickname {
                 font-weight: 300;
-                padding-left: 15px;
                 opacity: 0.4;
-                font-size: 90%;
+                font-size: 88%;
             }
 
         .profile-user-job {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28751226/80496765-4c716b80-8972-11ea-9e3a-681abcb6b2d2.png)

Шрифт сделал 88%, потому что при 90%, если у чела никнейм 32 символа, один символ будет переноситься на новую строку  😤

#30 