### PR TITLE
Add total votes for battles

### DIFF
--- a/frontend/html/posts/widgets/battle_stats.html
+++ b/frontend/html/posts/widgets/battle_stats.html
@@ -15,6 +15,11 @@
     <div class="post-comments-title">
         <span class="battle-side-a-color">{{ total_arguments.a }} {{ total_arguments.a | rupluralize:"аргумент,аргумента,аргументов" }} за первое</span>
         и
-        <span class="battle-side-b-color">{{ total_arguments.b }} за второе</span> 👇
+        <span class="battle-side-b-color">{{ total_arguments.b }} за второе</span>
+    </div>
+    <div class="post-comments-title">
+        <span class="battle-side-a-color">{{ total_votes.a }} {{ total_votes.a | rupluralize:"голос,голоса,голосов" }} за первое</span>
+        и
+        <span class="battle-side-b-color">{{ total_votes.b }} за второе</span> 👇
     </div>
 {% endif %}


### PR DESCRIPTION
## Отображаем общее количество голосов в Баттлах

**Общее количество голосов** это сумма голосов за **прямые** комментарии в баттле. 
Голоса за комментарии n-го уровня (например, ответ на прямой комментарий) не учитываются.

## Как это выглядит
<img width="671" alt="Screenshot 2020-04-29 at 20 23 10" src="https://user-images.githubusercontent.com/10001148/80637653-4608ef80-8a57-11ea-8fea-e752496e4421.png">


Еще можно отобразить так:
<img width="512" alt="Screenshot 2020-04-29 at 20 08 32" src="https://user-images.githubusercontent.com/10001148/80636361-3e484b80-8a55-11ea-9756-dddaf3c4c9ed.png">

Мне лично первый вариант показался несколько чище и понятнее, но сильных предпочтений нет.