### PR TITLE
By default invert logo for dark themers

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -34,6 +34,12 @@
                 filter: invert();
             }
 
+            @media (prefers-color-scheme: dark) {
+                html:not([theme]) .menu-logo img {
+                    filter: invert();
+                }
+            }
+
     .menu-avatar {
         width: 40px;
         height: 40px;


### PR DESCRIPTION
otherwise if you didn't choose theme yet and have 'prefer dark=true' set on OS level you see black :crossed_swords: instead of white one