### PR TITLE
Add npm install before watch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   club_app: &app
@@ -17,11 +17,12 @@ services:
       - REDIS_HOST=redis
     restart: always
     volumes:
-      - .:/app:delegated  # enable hot code reload in debug mode
+      - .:/app:delegated # enable hot code reload in debug mode
     depends_on:
       - postgres
       - redis
       - queue
+      - webpack
     ports:
       - "8000:8000"
 
@@ -49,11 +50,11 @@ services:
     image: postgres:11
     container_name: club_postgres
     environment:
-        - POSTGRES_USER=postgres
-        - POSTGRES_PASSWORD=postgres
-        - POSTGRES_DB=vas3k_club
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=vas3k_club
     ports:
-        - 5432
+      - 5432
 
   redis:
     image: redis:alpine

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "./node_modules/.bin/webpack --config webpack.config.js",
+    "prewatch": "npm install",
     "watch": "npm run build -- --watch"
   },
   "keywords": [],


### PR DESCRIPTION
 Issue is - if you don't have node_modules present in `frontend/` folder, `docker-compose up` will fail (webpack - command not found).
This add running `npm install` whenever `npm run watch` is running. It's slowly only on first run, consequent are almost noop.
Also add depends_on for club, so the startup sequence is slightly different and you have a higher chance of not seeing issues caused by build files not available resulting in django error view (it's still possible)