### PR TITLE
added meta tags for transparent status bar

### DIFF
--- a/frontend/html/common/meta.html
+++ b/frontend/html/common/meta.html
@@ -2,3 +2,5 @@
 <meta name="description" content="{{ settings.APP_DESCRIPTION }}">
 <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0">
 <meta name="format-detection" content="telephone=no">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Added apple-mobile-web-app-capable to be able to use apple-mobile-web-app-status-bar-style, so that in PWA-mode on iOS the app would have transparent status bar
![image](https://user-images.githubusercontent.com/19980512/81063082-dde75d00-8edf-11ea-9106-0aad3f2a038d.png)
