### PR TITLE
Fix the loading CSS in landing

### DIFF
--- a/frontend/html/landing.html
+++ b/frontend/html/landing.html
@@ -10,8 +10,7 @@
         {% include "common/og.html" %}
     {% endblock %}
     {% include "common/favicon.html" %}
-    {% include "common/js.html" %}
-    {% block js %}{% endblock %}
+    {% render_bundle "main" "css" %}
 </head>
 <body>
 
@@ -95,5 +94,8 @@
         </div>
     </div>
 {% endblock %}
+
+    {% include "common/js.html" %}
+    {% block js %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
Сейчас для неавторизованного пользователя выглядит так: ![vas3k club_](https://user-images.githubusercontent.com/24303010/81108211-03488b00-8f21-11ea-907d-34425d9a594a.png)

Стоит вынести копипасту между лендингом и основный лейаутом в общий шаблон, чтобы больше так не ошибаться.