### PR TITLE
changed grid-column-end for bold comments

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -477,7 +477,7 @@
 
     .comment-layout-block .comment-body {
         grid-column-start: 1;
-        grid-column-end: 3;
+        grid-column-end: 2;
         grid-row-start: 2;
         grid-row-end: 3;
         justify-self: stretch;


### PR DESCRIPTION
Fixes #37 
Предлагаю сделать так, всё равно запиненные блоки отличаются от обычных комментариев.
Будут уже, чем обычные, зато ничего не наезжает!
Получается вот так: 
![image](https://user-images.githubusercontent.com/19980512/81117977-b076cf80-8f30-11ea-9b8e-cd08977d246e.png)

Если можно сделать как-то получше, чтобы текст обтекал именно в одном месте иконку пина — подскажи, плиз.