### PR TITLE
Include anchor in action of comments order form

### DIFF
--- a/frontend/html/posts/show/layout.html
+++ b/frontend/html/posts/show/layout.html
@@ -36,7 +36,7 @@
                             {{ post.comment_count }}  {{ post.comment_count | rupluralize:"комментарий,комментария,комментариев" }} 👇
                         </a>
 
-                        <form action="." method="get" class="post-comments-order">
+                        <form action=".#comments" method="get" class="post-comments-order">
                             <select name="comment_order" onchange="this.form.submit()">
                                 <option value="-upvotes" {% if comment_order == "-upvotes" %}selected{% endif %}>по крутости</option>
                                 <option value="-created_at" {% if comment_order == "-created_at" %}selected{% endif %}>по свежести</option>


### PR DESCRIPTION
Сейчас если меняешь сортировку комментариев в посте, то страница перезагружается полностью и ты оказываешься вверху страницы.

С длинными обсуждаемыми постами выходит несколько неудобно. Заходишь, чтобы почитать новые комментарии, долго скроллишь до формы сортировки, меняешь сортировку  на "по свежести"  и скроллишь снова.