### PR TITLE
#188 Fix upvote button text overlap on mobile

### DIFF
--- a/frontend/static/css/posts.css
+++ b/frontend/static/css/posts.css
@@ -108,10 +108,11 @@
                     left: auto;
                     right: 0;
                     z-index: 1;
-                }
-
-                .post-type-post .text-body > *:first-child {
-                    padding-right: 80px;
+                    float: right;
+                    display: block;
+                    margin-bottom: 1.5em;
+                    margin-left: 1.5em;
+                    position: relative;
                 }
             }
 
@@ -203,8 +204,6 @@
         width: 100%;
         font-style: normal;
         padding: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
         box-sizing: border-box;
     }
 


### PR DESCRIPTION
Will fix #188 
Тикет в трелло: https://trello.com/c/As0ssw23/111-мобильная-версия-клуба-элемент-счетчика-плюсов-в-intro-перекрывает-текст

В изменениях убраны `overflow: hidden` и `text-overflow: ellipsis` для тегов в посте, возможно, был не прав и оно где-то нужно.

Было:
![CleanShot 2020-05-23 at 05 50 46](https://user-images.githubusercontent.com/131331/82720179-a20f0e80-9cb9-11ea-99de-e12691ec27e6.jpeg)

Стало:
![CleanShot 2020-05-23 at 05 50 35](https://user-images.githubusercontent.com/131331/82720184-a804ef80-9cb9-11ea-9387-d02186c0ae82.jpeg)
