### PR TITLE
add nltk to dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ WORKDIR /app
 ADD . /app
 
 RUN pip install --no-cache-dir pipenv \
-    && pipenv install --dev
+    && pipenv install --dev \ 
+    && pip install --no-cache-dir nltk 
+  
+RUN [ "python", "-c", "import nltk; nltk.download('punkt')" ]


### PR DESCRIPTION
Судя по всему, сейчас контейнер не содержит nltk либо не импортирует сам punkt, отчего роут с ссылкой валится локально.
```
club_app            |   Resource punkt not found.
club_app            |   Please use the NLTK Downloader to obtain the resource:
```
