### PR TITLE
Use full name and position in intro items

### DIFF
--- a/frontend/html/posts/items/intro.html
+++ b/frontend/html/posts/items/intro.html
@@ -7,7 +7,9 @@
 
     <div class="feed-post-header">
         <div class="feed-post-title">
-            <a href="{% url "show_post" post.type post.slug %}">{{ post.title }}</a>
+            <a href="{% url "show_post" post.type post.slug %}">
+                <span>#intro: </span><span class="user-name {% if user.is_banned %}user-name-is-banned{% endif %}">{{ post.author.full_name }}</span>{% if me %}<span class="user-position">, {{ post.author.position }}</span>{% endif %}
+            </a>
             {% if post.label %}
                 {% include "posts/widgets/label.html" with label=post.label %}
             {% endif %}

--- a/frontend/html/posts/show/post.html
+++ b/frontend/html/posts/show/post.html
@@ -13,7 +13,12 @@
                 {% endif %}
             </div>
             <div class="post-title">
-                {{ post.title | rutypography }}
+                {% if post.type == "intro" %}
+                    #intro: {{ post.author.full_name | rutypography }}
+                {% else %}
+                    {{ post.title | rutypography }}
+                {% endif %}
+
                 {% if post.author == me or me.is_moderator %}
                     <a href="{% url "edit_post" post.slug %}" class="button post-edit-button"><i class="fas fa-edit"></i></a>
                 {% endif %}

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1306,6 +1306,10 @@
         }
     }
 
+    .feed-post-type-intro .user-position {
+        opacity: 0.7;
+    }
+
 .feed-post-type-weekly_digest .feed-post-author {
     font-size: 30px;
     padding-right: 10px;


### PR DESCRIPTION
Отображение полного имени и должности для новых интро вместо никнейма, так как хочется видеть больше данных о новых членах клуба, листая ленту. Думаю, компанию в ленте отображать не обязательно, это менее важная и постоянная информация.

Closes #229 