### PR TITLE
[#240]: correct mentions retrieval in digest

### DIFF
--- a/notifications/views.py
+++ b/notifications/views.py
@@ -149,7 +149,7 @@ def daily_digest(request, user_slug):
     # Mentions
     mentions = Comment.visible_objects() \
         .filter(**created_at_condition) \
-        .filter(text__contains=f"@{user.slug}", is_deleted=False)\
+        .filter(text__regex=fr"@\y{user.slug}\y", is_deleted=False)\
         .exclude(reply_to__author=user)\
         .order_by("-upvotes")[:5]
 


### PR DESCRIPTION
Сейчас меншоны фильтруются по вхождению ника:
```
.filter(text__contains=f"@{user.slug}", is_deleted=False)
```
Это приводит к тому, что у счастливчиков с никами `Max` и `MaxSuper` будет вдвое больше меншонов, чем нужно.

Чиним это заменой `text__contains` на `text__regex`:
```
.filter(text__regex=fr"@\y{user.slug}\y", is_deleted=False)
```

Результат до:
<img width="509" alt="Screenshot 2020-06-02 at 23 45 37" src="https://user-images.githubusercontent.com/10001148/83577071-2ae44080-a52b-11ea-9c60-b7872f7ed2fe.png">

Результат после:
<img width="525" alt="Screenshot 2020-06-02 at 23 48 17" src="https://user-images.githubusercontent.com/10001148/83577207-89a9ba00-a52b-11ea-8261-1074c6ef501f.png">

Closes #240.