### PR TITLE
Hotfix/docker compose and ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,29 +3,28 @@ name: check_pr
 on: [pull_request]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
 
-# Disabled due errors with gdal installation
-#  lint:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#    - uses: actions/checkout@master
-#    - uses: actions/setup-python@v2
-#      with:
-#        python-version: '3.8'
-#        architecture: 'x64'
-#    - name: Install requirements
-#      run: |
-#        pip install --no-cache-dir pipenv
-#        pipenv install --dev
-#    - name: run lint
-#      run: make test-ci
-#      # continue-on-error: true
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+        architecture: 'x64'
+    - name: Install requirements
+      run: |
+        pip install --no-cache-dir flake8
+    - name: run flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --statistics
+
 
   dockerize:
     runs-on: ubuntu-latest
-#    needs: lint
-
     steps:
       - uses: actions/checkout@master
       - name: Build the docker-compose stack
@@ -36,7 +35,7 @@ jobs:
           time: '20s'
       - name: Check db migrate on container
         run: |
-          docker-compose exec -T club_app make migrate
+          docker-compose exec -T club_app make docker-migrate
       - name: Check build frontend on container
         run: |
           docker-compose exec -T webpack npm run build

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ requirements:  ## Generate requirements.txt for production
 migrate:  ## Migrate database to the latest version
 	pipenv run python3 manage.py migrate
 
+docker-migrate:
+	python3 manage.py migrate
 
 build-frontend:  ## Runs webpack
 	npm run --prefix frontend build

--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,16 @@ run-dev:  ## Runs dev server
 run-queue:  ## Runs task broker
 	pipenv run python manage.py qcluster
 
-run-queue-production:
+docker-run-queue:
 	python manage.py qcluster
 
 run-uvicorn:  ## Runs uvicorn (ASGI) server in managed mode
 	pipenv run uvicorn --fd 0 --lifespan off club.asgi:application
 
 docker-run-dev:  ## Runs dev server in docker
-	pipenv run python ./utils/wait_for_postgres.py
-	pipenv run python manage.py migrate
-	pipenv run python manage.py runserver 0.0.0.0:8000
+	python ./utils/wait_for_postgres.py
+	python manage.py migrate
+	python manage.py runserver 0.0.0.0:8000
 
 docker-run-production:  ## Runs production server in docker
 	python3 manage.py migrate
@@ -39,6 +39,7 @@ requirements:  ## Generate requirements.txt for production
 
 migrate:  ## Migrate database to the latest version
 	pipenv run python3 manage.py migrate
+
 
 build-frontend:  ## Runs webpack
 	npm run --prefix frontend build

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -30,7 +30,7 @@ services:
 
   queue:
     <<: *app
-    command: make run-queue-production
+    command: make docker-run-queue
     container_name: club_queue
     depends_on:
       - postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     build:
       dockerfile: dev.dockerfile
       context: .
-    command: make run-queue
+    command: make docker-run-queue
     environment:
       - DEBUG=true
       - PYTHONUNBUFFERED=1
@@ -70,10 +70,3 @@ services:
     volumes:
       - .:/app:delegated
     working_dir: /app/frontend
-
-  migrate_and_init:
-    <<: *app
-    container_name: club_migrate_and_init
-    restart: "no"
-    ports: []
-    command: make migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ cryptography==2.8
 cssselect==1.1.0
 cssutils==1.0.2
 decorator==4.4.2
+django-debug-toolbar==2.2
 django-picklefield==2.1.1
 django-q-sentry==0.1.1
 django-q[sentry]==1.2.1

--- a/utils/images.py
+++ b/utils/images.py
@@ -29,7 +29,7 @@ def upload_image_bytes(
 
         try:
             image.save(saved_image)
-        except OSError:
+        except OSError as ex:
             log.warning(f"Error saving image data: {ex}")
             return None
 


### PR DESCRIPTION
- Починил `docker-compose up` из `README.md`
- Починил CI lint
- Починил  fix #258 

Давненько не ковырял python-экосистему, может не вижу чего-то очевидного.

Из важного:
В `Makefile` убрал в таргетах используемых в `compose` использование `pipenv`, по причинам:
- в образах уже присутствуют все зависимости
- необходимость генерировать `venv` отсутствует
- для использования `pipenv`, как я понял, необходимо явно прогонять `pipenv install`, что видится лишним

И есть вопрос:
Не уследил логики, зачем в изначальной джобе `lint` была установка `pipenv` и всех возможных зависимостей проекта, хотя достаточно `flake8`?
