### PR TITLE
Поправил лейаут в футере на мобилках

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -71,8 +71,8 @@
 }
 
 .footer {
-    display: grid;
-    grid-template-columns: auto 100px;
+    display: flex;
+    justify-content: space-between;
     margin: 0 auto;
     max-width: var(--max-content-width);
 }


### PR DESCRIPTION


###  чуть больше деталей

там `footer-right` был прибит 100 пикселями, которых иногда даже нет. теперь оно адаптивно
![image](https://user-images.githubusercontent.com/3356474/84147842-3d5cfd80-aa88-11ea-8754-4159e4d8ea00.png)

Было: 
![Screenshot 2020-06-09 at 16 28 36](https://user-images.githubusercontent.com/3356474/84147268-4dc0a880-aa87-11ea-866d-2ee02e21c535.png)

Стало:
![image](https://user-images.githubusercontent.com/3356474/84147293-55804d00-aa87-11ea-8a78-17418d5b4910.png)

Для детальной информации: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Relationship_of_Grid_Layout
