### PR TITLE
Remove decapitalizing from battle comments

### DIFF
--- a/frontend/html/comments/types/battle.html
+++ b/frontend/html/comments/types/battle.html
@@ -3,7 +3,7 @@
 {% load battle %}
 {% load posts %}
 <div class="battle-comment-prefix battle-comment-prefix-side-{{ comment.metadata.battle.side }}">
-    за {{ comment.battle_side|uncapitalize }}
+    за «{{ comment.battle_side }}»
 </div>
 <div class="block comment comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
     <div class="comment-header">


### PR DESCRIPTION
Заметил неприятный момент в батле — декапитализация аргумента в углу коммента часто работает очень плохо.
Попытался придумать ультимейт способ, но не смог, поэтому подумал что лучше привести все строки такого рода к общему виду, так же как это сделано в самом верху страницы.

![1](https://user-images.githubusercontent.com/16938543/84481244-7b336f00-ac9e-11ea-827c-f9328b64362d.jpg)
![2](https://user-images.githubusercontent.com/16938543/84481251-7d95c900-ac9e-11ea-9fd1-9bbb0e3cb39a.jpg)
![3](https://user-images.githubusercontent.com/16938543/84481261-7f5f8c80-ac9e-11ea-92d1-52b1fdc92580.jpg)
