### PR TITLE
Считаем новые сообщения правильно

### DIFF
--- a/comments/views.py
+++ b/comments/views.py
@@ -51,7 +51,7 @@ def create_comment(request, post_slug):
             # update the shitload of counters :)
             request.me.update_last_activity()
             Comment.update_post_counters(post)
-            PostView.increment_unread_comments(post)
+            PostView.increment_unread_comments(comment)
             PostView.register_view(
                 request=request,
                 user=request.me,
@@ -148,10 +148,12 @@ def delete_comment(request, comment_id):
     if not comment.is_deleted:
         # delete comment
         comment.delete(deleted_by=request.me)
+        PostView.decrement_unread_comments(comment)
     else:
         # undelete comment
         if comment.deleted_by == request.me or request.me.is_moderator:
             comment.undelete()
+            PostView.increment_unread_comments(comment)
         else:
             raise AccessDenied(
                 title="Нельзя!",

--- a/posts/models.py
+++ b/posts/models.py
@@ -360,9 +360,14 @@ class PostView(models.Model):
         return post_view
 
     @classmethod
-    def increment_unread_comments(cls, post):
-        PostView.objects.filter(post=post, user__isnull=False)\
+    def increment_unread_comments(cls, comment):
+        PostView.objects.filter(post=comment.post, last_view_at__lt = comment.created_at, user__isnull=False)\
             .update(unread_comments=F("unread_comments") + 1)
+
+    @classmethod
+    def decrement_unread_comments(cls, comment):
+        PostView.objects.filter(post=comment.post, last_view_at__lt = comment.created_at, user__isnull=False)\
+            .update(unread_comments=F("unread_comments") - 1)
 
 
 class PostSubscription(models.Model):


### PR DESCRIPTION
## Что

Пришел написать что-нибудь во фронтенде, но в итоге пофиксил счетчик непрочитанных сообщений.

## Как 

Добавил статический метод, который делает декремент счетчика непрочитанных сообщений.

Оба метода — декремент и инкремент обновляют счетчик непрочитанных только для тех пользователей, которые приходили до даты создания комментария. Если удалили или восстановили старый комментарий, он не появится в счетчике.

Closes #252 