### PR TITLE
Load tags in docker-run-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ run-uvicorn:  ## Runs uvicorn (ASGI) server in managed mode
 docker-run-dev:  ## Runs dev server in docker
 	python ./utils/wait_for_postgres.py
 	python manage.py migrate
+	python manage.py update_tags
 	python manage.py runserver 0.0.0.0:8000
 
 docker-run-production:  ## Runs production server in docker


### PR DESCRIPTION
Just load tags in docker-run-dev command

Fix #272

```
python ./utils/wait_for_postgres.py
Waiting for postgres
Waiting for postgres
Waiting for postgres
Postgres had started
python manage.py migrate
Operations to perform:
  Apply all migrations: auth, comments, django_q, landing, posts, search, users
Running migrations:
  Applying users.0001_initial... OK
  Applying auth.0001_initial... OK
  Applying posts.0001_initial... OK
  Applying comments.0001_initial... OK
  Applying comments.0002_auto_20200416_0937... OK
  ...
  Applying users.0011_auto_20200526_1126... OK
  Applying users.0012_auto_20200602_1121... OK
  Applying users.0013_auto_20200602_1139... OK
python manage.py update_tags
42 hobbies
48 personal
0 tech
23 club
Done 🥙
python manage.py runserver 0.0.0.0:8000
Watching for file changes with StatReloader
Performing system checks...

System check identified no issues (0 silenced).
June 15, 2020 - 13:10:21
Django version 3.0.4, using settings 'club.settings'
Starting development server at http://0.0.0.0:8000/
Quit the server with CONTROL-C.
```