### PR TITLE
Скрыть ссылки «отписаться от дайджеста» из футера

### DIFF
--- a/notifications/management/commands/send_weekly_digest.py
+++ b/notifications/management/commands/send_weekly_digest.py
@@ -35,6 +35,13 @@ class Command(BaseCommand):
 
         digest_html = digest_html_response.text
 
+        digest_html_no_footer_response = requests.get(digest_url, params={"no_footer": 1})
+        if digest_html_no_footer_response.status_code > 400:
+            log.error("Weekly digest without footer error: bad status code", extra={"html": digest_html_no_footer_response.text})
+            return
+
+        digest_no_footer_html = digest_html_no_footer_response.text
+
         # save digest as a post
         issue = (datetime.utcnow() - settings.LAUNCH_DATE).days // 7
         year, week, _ = (datetime.utcnow() - timedelta(days=7)).isocalendar()
@@ -44,8 +51,8 @@ class Command(BaseCommand):
             defaults=dict(
                 author=User.objects.filter(slug="vas3k").first(),
                 title=f"Клубный журнал. Итоги недели. Выпуск #{issue}",
-                html=digest_html,
-                text=digest_html,
+                html=digest_no_footer_html,
+                text=digest_no_footer_html,
                 is_pinned_until=datetime.utcnow() + timedelta(days=1),
                 is_visible=True,
                 is_public=True,

--- a/notifications/management/commands/send_weekly_digest.py
+++ b/notifications/management/commands/send_weekly_digest.py
@@ -35,12 +35,12 @@ class Command(BaseCommand):
 
         digest_html = digest_html_response.text
 
-        digest_html_no_footer_response = requests.get(digest_url, params={"no_footer": 1})
-        if digest_html_no_footer_response.status_code > 400:
-            log.error("Weekly digest without footer error: bad status code", extra={"html": digest_html_no_footer_response.text})
+        no_footer_digest_response = requests.get(digest_url, params={"no_footer": 1})
+        if no_footer_digest_response.status_code > 400:
+            log.error("Weekly digest without footer error: bad status code", extra={"html": no_footer_digest_response.text})
             return
 
-        digest_no_footer_html = digest_html_no_footer_response.text
+        no_footer_digest_html = no_footer_digest_response.text
 
         # save digest as a post
         issue = (datetime.utcnow() - settings.LAUNCH_DATE).days // 7
@@ -51,8 +51,8 @@ class Command(BaseCommand):
             defaults=dict(
                 author=User.objects.filter(slug="vas3k").first(),
                 title=f"Клубный журнал. Итоги недели. Выпуск #{issue}",
-                html=digest_no_footer_html,
-                text=digest_no_footer_html,
+                html=no_footer_digest_html,
+                text=no_footer_digest_html,
                 is_pinned_until=datetime.utcnow() + timedelta(days=1),
                 is_visible=True,
                 is_public=True,

--- a/notifications/templates/emails/layout.html
+++ b/notifications/templates/emails/layout.html
@@ -344,14 +344,16 @@
             {% block body %}{% endblock %}
         </main>
 
-        <footer>
-            {% block footer %}{% endblock %}
-            {% block unsubscribe %}
-                <p style="text-align: right;">
-                    Если вам больше не хочется никогда получать никаких писем от Клуба,<br> нажмите <a href="{{ settings.APP_HOST }}/notifications/unsubscribe/%user_id%/%secret_code%/">отписаться вообще от всего</a>.
-                </p>
-            {% endblock %}
-        </footer>
+        {% if not is_footer_excluded %}
+            <footer>
+                {% block footer %}{% endblock %}
+                {% block unsubscribe %}
+                    <p style="text-align: right;">
+                        Если вам больше не хочется никогда получать никаких писем от Клуба,<br> нажмите <a href="{{ settings.APP_HOST }}/notifications/unsubscribe/%user_id%/%secret_code%/">отписаться вообще от всего</a>.
+                    </p>
+                {% endblock %}
+            </footer>
+        {% endif %}
 
     </div>
     <!--[if (gte mso 9)|(IE)]>

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -252,6 +252,8 @@ def weekly_digest(request):
     if not author_intro and not posts and not comments:
         raise Http404()
 
+    is_footer_excluded = "no_footer" in request.GET
+
     return render(request, "emails/weekly.html", {
         "posts": posts,
         "comments": comments,
@@ -262,5 +264,6 @@ def weekly_digest(request):
         "top_video_post": top_video_post,
         "featured_post": featured_post,
         "author_intro": author_intro,
-        "issue_number": (end_date - settings.LAUNCH_DATE).days // 7
+        "issue_number": (end_date - settings.LAUNCH_DATE).days // 7,
+        "is_footer_excluded": is_footer_excluded
     })


### PR DESCRIPTION
Closes #170 

Объяснял в самом баге варианты исправления, которые я вижу:

* парсить отрендеренный html и выкидывать footer перед сохранением поста. Не нравится, потому что слишком неочевидно
* добавить к запросу на рендеринг дайджеста параметр запроса no_footer, который будет рендерить страницу без футера со ссылками. Это более читаемо, но тогда при рассылке придется два раза кинуть запрос на рендер дайджеста — с футером и без него

Я выбрал второй вариант, но готов все поменять, если это не подходит