### PR TITLE
Fix: части сайта просвечивают через бэкграунд при просмотре полноразмерных картинок

### DIFF
--- a/frontend/static/js/App.js
+++ b/frontend/static/js/App.js
@@ -233,7 +233,7 @@ const App = {
             keyboard: true,
             cubicBezier: "cubic-bezier(.2, 0, .1, 1)",
             background: "rgba(0, 0, 0, .4)",
-            zIndex: 2147483647,
+            zIndex: 1e6,
         });
     },
     blockCommunicationFormsResubmit() {


### PR DESCRIPTION
Closes #298 

Значение, использованное для `z-index` либы, которая показывает картинки было слишком большое. `z-index` бэкграунда считается как `z-index картинки - 1`. Это приводило к переполнению целочисленного диапазона значений и в итоге к бэкграунду применялось `z-index: -1;`

Решение: уменьшить z-index

До | После
------------ | -------------
![before](https://user-images.githubusercontent.com/1469636/86643348-eb52bd80-bfdc-11ea-9859-51b6196fdd31.png) | ![После](https://user-images.githubusercontent.com/1469636/86643078-af1f5d00-bfdc-11ea-8890-4d72efb0cb71.png)

