### PR TITLE
[fix] #296 fix text-rendering for iOS 14/macOS Big Sur

### DIFF
--- a/frontend/static/css/theme.css
+++ b/frontend/static/css/theme.css
@@ -95,7 +95,7 @@ body {
     line-height: 1.42;
     color: var(--text-color);
     background-color: var(--bg-color);
-    text-rendering: optimizeLegibility;
+    text-rendering: optimizeSpeed;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 }


### PR DESCRIPTION
closes #296 

Не смог понять, зачем @vas3k сделал `optimizeLegibility`, но с `optimizeSpeed` на iOS 14/macOS Big Sur шрифты становятся нормальными. В других ОС/браузерах шрифт остался таким же, но незначительно поменялось расстояние между некоторыми буквами