### PR TITLE
Fixed tags size and tags mobile view.

### DIFF
--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -604,11 +604,10 @@ input[type=range]:focus::-ms-fill-upper {
         }
 
     .topic-type-card {
-        display: inline-block;
+        display: flex;
         margin-top: 10px;
         padding: 10px 20px 10px 10px;
         box-sizing: border-box;
-        flex-direction: column;
         align-items: center;
         font-size: 100%;
         border-radius: 30px;


### PR DESCRIPTION
Before:
<img width="368" alt="Screen Shot 2020-07-20 at 10 23 38 PM" src="https://user-images.githubusercontent.com/32079217/87978366-f4fa1c00-cad8-11ea-8f13-d2eb355ff2c4.png">

After:
<img width="368" alt="Screen Shot 2020-07-20 at 10 23 00 PM" src="https://user-images.githubusercontent.com/32079217/87978397-004d4780-cad9-11ea-81f7-e749cb304633.png">


Если это не авторская задумка, то должно пофиксить.