### PR TITLE
Fix Twitter Card

### DIFF
--- a/frontend/html/common/og.html
+++ b/frontend/html/common/og.html
@@ -6,7 +6,7 @@
 <meta property="og:description" content="{{ settings.APP_DESCRIPTION }}">
 <meta property="og:image" content="{% static "images/share.png" %}">
 
-<meta name="twitter:card" content="summary_image">
+<meta name="twitter:card" content="summary">
 <meta name="twitter:title" content="{{ settings.APP_NAME }}">
 <meta name="twitter:description" content="{{ settings.APP_DESCRIPTION }}">
 <meta name="twitter:image" content="{% static "images/share.png" %}">


### PR DESCRIPTION
If you check any public URL(e.g. https://vas3k.club/project/4060/) with [Twitter Card Validator](https://cards-dev.twitter.com/validator), you'll get:
```
INFO:  Page fetched successfully
INFO:  19 metatags were found
INFO:  twitter:card = summary_image tag found
ERROR: The 'summary_image' card type provided by the twitter:card metatag is not a valid card type. Valid card types are 'app', 'player', 'summary' and 'summary_large_image'. (Card error)
```
Seems like that will solve the problem with generating previews in Twitter:
- changing `summary_image` to `summary`