### PR TITLE
Hide scrollbar if it's not needed in a `pre` block

### DIFF
--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -354,7 +354,7 @@
         border-radius: 20px;
         margin-top: 2em;
         margin-bottom: 2em;
-        overflow-x: scroll;
+        overflow-x: auto;
         overflow-y: hidden;
     }
 


### PR DESCRIPTION
До:

![Screen Shot 2020-08-01 at 16 19 38](https://user-images.githubusercontent.com/654597/89103577-1f21d700-d413-11ea-9b15-e39dddf197d4.png)

После:

![Screen Shot 2020-08-01 at 16 21 49](https://user-images.githubusercontent.com/654597/89103584-20eb9a80-d413-11ea-9a3e-d19f5df4a0bf.png)

Если текст не влазит, то скроллбар появится.
