### PR TITLE
Новый шаблон для рендеринга комментариев в поиске и профиле

### DIFF
--- a/frontend/html/comments/types/snippet.html
+++ b/frontend/html/comments/types/snippet.html
@@ -1,0 +1,31 @@
+{% load text_filters %}
+{% load comments %}
+<div class="comment comment-layout-normal {% if comment.is_pinned %}comment-is-pinned{% endif %}">
+    <div class="comment-header">
+        <div class="user user-small">
+            <span class="user-avatar">
+                <span class="avatar" style="background-image: url('{{ comment.author.get_avatar }}');"></span>
+            </span>
+            <span class="user-info">
+                <span>
+                    <span class="user-name">{{ comment.author.full_name }}</span><span class="user-position">, {{ comment.author.position }}</span>
+                    {% if comment.author.hat %}{% include "users/widgets/hat.html" with hat=comment.author.hat %}{% endif %}
+                </span>
+            </span>
+            <span class="user-footer">{{ comment.created_at | cool_date }}</span>
+        </div>
+    </div>
+    <div class="comment-rating">
+        <span class="upvote upvote-disabled">{{ comment.upvotes }}</span>
+
+        {% if comment.is_pinned %}
+        <div class="comment-pinned-icon"><i class="fas fa-thumbtack"></i></div>
+        {% endif %}
+    </div>
+    <div class="comment-body">
+        <div class="text-body text-body-type-comment">
+            {% render_comment comment %}
+        </div>
+    </div>
+    <a class="block-link" href="{% url "show_post" comment.post.type comment.post.slug %}#comment-{{ comment.id }}"></a>
+</div>

--- a/frontend/html/search.html
+++ b/frontend/html/search.html
@@ -33,7 +33,7 @@
                         {% include "posts/items/items.html" with post=result.post upvote_disabled=True %}
                     {% endif %}
                     {% if result.comment %}
-                        {% include "comments/types/normal.html" with comment=result.comment upvote_disabled=True %}
+                        {% include "comments/types/snippet.html" with comment=result.comment %}
                     {% endif %}
                     {% if result.profile %}
                         {% include "users/widgets/card.html" with user=result.profile %}

--- a/frontend/html/users/profile.html
+++ b/frontend/html/users/profile.html
@@ -215,30 +215,7 @@
             <div class="profile-comments">
                 <div class="profile-header">Последние комментарии</div>
                 {% for comment in comments %}
-                    <div class="block comment comment-layout-normal" id="comment-{{ comment.id }}">
-                        <div class="comment-header">
-                            <div class="user user-small">
-                                <span class="user-avatar">
-                                    <span class="avatar" style="background-image: url('{{ comment.author.get_avatar }}');"></span>
-                                </span>
-                                <span class="user-info">
-                                    {{ comment.post.title }}
-                                </span>
-                                <span class="user-footer">
-                                    {{ comment.created_at | date:"j E Y" }}
-                                </span>
-                            </div>
-                        </div>
-                        <div class="comment-body">
-                            <div class="text-body text-body-type-comment">
-                                {% render_comment comment %}
-                            </div>
-                        </div>
-                        <div class="comment-rating">
-                            <span class="upvote upvote-type-small">{{ comment.upvotes }}</span>
-                        </div>
-                        <a class="block-link" href="{% url "show_post" comment.post.type comment.post.slug %}#comment-{{ comment.id }}"></a>
-                    </div>
+                    {% include "comments/types/snippet.html" with comment=comment %}
                 {% endfor %}
             </div>
         {% endif %}


### PR DESCRIPTION
Добавил новый шаблон для рендеринга комментов вне страницы комментариев.

Старался сделать как можно более легковесным. Выкинул все ссылки и vue-компонент голосования. Любой клик по блоку переносит на этот коммент в посте.

#332 

## Скриншоты
![image](https://user-images.githubusercontent.com/1469636/89226658-9c4c7800-d5dc-11ea-8b0e-1d08f74a4b5e.png)

![image](https://user-images.githubusercontent.com/1469636/89226795-d9186f00-d5dc-11ea-9bf2-99a32d7ff9ea.png)
