### PR TITLE
WIP: Add video to allowed mime types for uploading #339

### DIFF
--- a/frontend/static/js/App.js
+++ b/frontend/static/js/App.js
@@ -18,13 +18,21 @@ const imageUploadOptions = {
     progressText: "![Загружаю файл...]()",
     urlText: "![]({filename})",
     errorText: "Ошибка при загрузке файла :(",
+    allowedTypes: [
+        // Images
+        "image/jpeg",
+        "image/png",
+        "image/jpg",
+        "image/gif",
+        // Videos (for animation only)
+        "video/mp4",
+        "video/quicktime" // .mov (macOS' default record format)
+    ],
     extraHeaders: {
         "Accept": "application/json",
     },
     extraParams: {
         code: imageUploadCode,
-        convert_to: "image/jpeg",
-        quality: 85,
     },
 };
 


### PR DESCRIPTION
Post editor should handle video files as a replacement
for gif files. And this feature established on the file server
and post templates, but code mirror file upload plugin
disallow upload videos by default. Fixed this.

Also, removed `convert_to` and `quality` extra params (they
handled by file server) because these parameters have no
sense if we upload files with different types.

NOTE: Video files upload works only via drag and drop,
not copy-paste.

https://github.com/vas3k/vas3k.club/issues/339

Wait for [this small issue](https://github.com/vas3k/vas3k.club/issues/339#issuecomment-669383319) in file server