### PR TITLE
Remove 'Ubuntu' font from code styles, as far as it is not monospace

### DIFF
--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -360,7 +360,7 @@
     }
 
     .text-body code {
-        font-family: Ubuntu, monospace;
+        font-family: monospace;
     }
 
     .text-body pre {
@@ -376,7 +376,7 @@
     }
 
     .text-body pre code {
-        font-family: Ubuntu, monospace;
+        font-family: monospace;
         display: block;
         padding: 20px 25px;
     }

--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -360,7 +360,7 @@
     }
 
     .text-body code {
-        font-family: monospace;
+        font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
     }
 
     .text-body pre {
@@ -376,7 +376,7 @@
     }
 
     .text-body pre code {
-        font-family: monospace;
+        font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
         display: block;
         padding: 20px 25px;
     }


### PR DESCRIPTION
resolves #370

Using GitHub's monospace font stack, for prettier rendering.

| Before | After |
|-|-|
| <img width="798" alt="image" src="https://user-images.githubusercontent.com/827338/91106013-7851e480-e626-11ea-9be8-9cc74af8551b.png"> | <img width="794" alt="image" src="https://user-images.githubusercontent.com/827338/91106057-97e90d00-e626-11ea-8cbc-500db97481c9.png"> |
