### PR TITLE
Исправлено дерганье в сафари

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1444,7 +1444,7 @@
         padding: 15px;
     }
 
-    .compose-form-text textarea {
+    .compose-form-text textarea.markdown-editor-full {
         padding: 20px;
         min-height: 500px;
         font-family: var(--serif-font);


### PR DESCRIPTION
fix issue #169

Проблема была в том, что внутри компонента с редактором есть 2 элемента textarea: 
1. реальный textarea, который отображается на мобильных устройствах и скрывается после инициализации CodeMirror (для него эти стили полезны)
2. вспомогательный textarea внутри CodeMirror, и ему становится реально плохо от `min-height: 500px;`

теперь стили применяются только к настоящему textarea