### PR TITLE
Improving CSS for bookmark controls

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1314,6 +1314,12 @@
         white-space: nowrap;
     }
 
+    .feed-post-footer .bookmark-button {
+        display: inline-block;
+        text-decoration: none;
+        opacity: 0.6;
+    }
+
     .feed-post-is-pinned {
         background-color: var(--opposite-block-bg-color);
         color: var(--opposite-text-color);


### PR DESCRIPTION
В режиме отображения поста всё, что идёт в класс post-date отображается тупо с opacity: 0.6 при базовом цвете `#DDD`. Это соответствует значению `#858585`.
В режиме отображения закладок цвет количества комментариев установлен тупо на `#999`.
Соответственно получается небольшое отличие между ними.
Я слабо вижу эту разницу и предпочёл повторить поведение кнопки в режиме поста.
Если есть идеи лучше -  дай знать.
