### PR TITLE
Fix console errors in mobile version

### DIFF
--- a/frontend/static/js/App.js
+++ b/frontend/static/js/App.js
@@ -129,7 +129,7 @@ const App = {
     },
 
     initializeMarkdownEditor() {
-        if (this.isMobile()) return; // we don't need fancy features on mobiles
+        if (this.isMobile()) return []; // we don't need fancy features on mobiles
 
         const fullMarkdownEditors = [...document.querySelectorAll(".markdown-editor-full")].reduce(
             (editors, element) => {

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -71,11 +71,15 @@ new Vue({
             function appendMarkdownTextareaValue(textarea, value) {
                 textarea.focus(); // on mobile
                 textarea.value = value;
-                const codeMirrorEditor = textarea.nextElementSibling.CodeMirror || textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
-                if (codeMirrorEditor !== undefined) {
-                    codeMirrorEditor.setValue(codeMirrorEditor.getValue() + value);
-                    codeMirrorEditor.focus();
-                    codeMirrorEditor.setCursor(codeMirrorEditor.lineCount(), 0);
+
+                // On mobile the next element sibling is undefined
+                if (textarea.nextElementSibling) {
+                    const codeMirrorEditor = textarea.nextElementSibling.CodeMirror || textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
+                    if (codeMirrorEditor !== undefined) {
+                        codeMirrorEditor.setValue(codeMirrorEditor.getValue() + value);
+                        codeMirrorEditor.focus();
+                        codeMirrorEditor.setCursor(codeMirrorEditor.lineCount(), 0);
+                    }
                 }
             }
 


### PR DESCRIPTION
Сейчас в консоли на мобильной версии вываливается ошибка "Cannot read property 'forEach' of undefined".

Это связано со следующим куском кода:
````ts
        const registeredEditors = this.initializeMarkdownEditor();

        setTimeout(function () {
            registeredEditors.forEach((editor) => {
                // textarea value after navigation might be restored after codemirror inited
                if (editor.element.value && !editor.codemirror.getValue()) {
                    editor.codemirror.setValue(editor.element.value);
                }
            });
        }, INITIAL_SYNC_DELAY);
````
Для мобильной версии сайта вызов initializeMarkdownEditor возвращал undefined.