### PR TITLE
Adding easy security headers

### DIFF
--- a/etc/nginx/i.vas3k.club.conf
+++ b/etc/nginx/i.vas3k.club.conf
@@ -33,7 +33,7 @@ server {
         add_header "Strict-Transport-Security" "max-age=31536000;includeSubDomains";
         add_header "X-Content-Type-Options" "nosniff";
         add_header "Referrer-Policy" "strict-origin-when-cross-origin";
-        add_header "Permissions-Policy" "accelerometer=(),camera=(),geolocation=(self "https://vas3k.club"),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()";
+        add_header "Permissions-Policy" "accelerometer=(),camera=(),geolocation=(),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()";
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/etc/nginx/i.vas3k.club.conf
+++ b/etc/nginx/i.vas3k.club.conf
@@ -30,6 +30,10 @@ server {
         add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS";
         add_header "Access-Control-Allow-Headers" "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range";
         add_header "Access-Control-Expose-Headers" "Content-Length,Content-Range";
+        add_header "Strict-Transport-Security" "max-age=31536000;includeSubDomains";
+        add_header "X-Content-Type-Options" "nosniff";
+        add_header "Referrer-Policy" "strict-origin-when-cross-origin";
+        add_header "Permissions-Policy" "accelerometer=(),camera=(),geolocation=(self "https://vas3k.club"),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()";
 
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/etc/nginx/vas3k.club.conf
+++ b/etc/nginx/vas3k.club.conf
@@ -52,6 +52,15 @@ server {
     location / {
         limit_req zone=club_limit burst=50 nodelay;
 
+        add_header "Access-Control-Allow-Origin" "*";
+        add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS";
+        add_header "Access-Control-Allow-Headers" "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range";
+        add_header "Access-Control-Expose-Headers" "Content-Length,Content-Range";
+        add_header "Strict-Transport-Security" "max-age=31536000;includeSubDomains";
+        add_header "X-Content-Type-Options" "nosniff";
+        add_header "Referrer-Policy" "strict-origin-when-cross-origin";
+        add_header "Permissions-Policy" "accelerometer=(),camera=(),geolocation=(self "https://vas3k.club"),gyroscope=(),magnetometer=(),microphone=(),payment=(),usb=()";
+
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
Я добавил то, что просто добавить. Есть пара нюансов:
- Про Permissions-Policy в комментариях говорят, что вроде ещё не все браузеры поддерживают по умолчанию (http://disq.us/p/2bxp2rt - комментарий от Craig Francis). Я все равно добавил, указал только, что мы можем геолокацию использовать (хз, используется уже или нет)
- Ещё возможно ты захочешь перепроверить Referrer-Policy - https://scotthelme.co.uk/a-new-security-header-referrer-policy/
- Не добавил Content-Security-Policy, там как-то не тривиально. Например, на том сайте такое значение:
> default-src 'self'; script-src 'self' 'report-sample' disqus.com c.disquscdn.com platform.instagram.com cdnjs.cloudflare.com scotthelme.disqus.com a.disquscdn.com go.disqus.com platform.twitter.com cdn.syndication.twimg.com syndication.twitter.com gist.github.com/ScottHelme/ www.googletagmanager.com www.google-analytics.com js.stripe.com; style-src 'self' 'report-sample' 'unsafe-inline' c.disquscdn.com a.disquscdn.com fonts.googleapis.com cdnjs.cloudflare.com platform.twitter.com assets-cdn.github.com githu…m syndication.twitter.com platform.twitter.com www.youtube-nocookie.com js.stripe.com; connect-src 'self' syndication.twitter.com links.services.disqus.com scotthelme.ghost.io; font-src 'self' cdnjs.cloudflare.com fonts.gstatic.com fonts.googleapis.com; form-action 'self' syndication.twitter.com; frame-ancestors 'none'; prefetch-src 'self' c.disquscdn.com disqus.com; object-src 'none'; base-uri 'none'; upgrade-insecure-requests; report-uri https://scotthelme.report-uri.com/r/d/csp/enforce; report-to default