### PR TITLE
Отображать ошибку, если падает запрос на загрузку media к комментарию

### DIFF
--- a/frontend/static/js/inline-attachment.js
+++ b/frontend/static/js/inline-attachment.js
@@ -266,6 +266,11 @@
                 me.onFileUploadError(xhr);
             }
         };
+
+        xhr.onerror = function () {
+            me.onFileUploadError(xhr);
+        };
+
         if (settings.beforeFileUpload(xhr) !== false) {
             xhr.send(formData);
         }


### PR DESCRIPTION
Фикс к этому:
https://github.com/vas3k/vas3k.club/issues/426

Почему фейлятся гифки, я не определила (я фронтендер 💁), но могу пофиксить отображение ошибки на фронте


