### PR TITLE
fix: app service name in compose

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,7 @@ jobs:
           time: '20s'
       - name: Check db migrate on container
         run: |
-          docker-compose exec -T club_app make docker-migrate
+          docker-compose exec -T app make docker-migrate
       - name: Check build frontend on container
         run: |
           docker-compose exec -T webpack npm run build

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 
 services:
-  club_app: &app
+  app:
     build:
       dockerfile: dev.dockerfile
       context: .


### PR DESCRIPTION
fixes an issue which occurs when a microservice from the compose networks sends a request to the django back-end. The request results into DisallowedHost exception with text `Invalid HTTP_HOST header: 'club_app:8000'. The domain name provided is not valid according to RFC 1034/1035.`. I refer to the solution from this stackoverflow answer: https://stackoverflow.com/a/52997937