### PR TITLE
Hide native radio button on user digest selector

### DIFF
--- a/frontend/html/users/edit/notifications.html
+++ b/frontend/html/users/edit/notifications.html
@@ -36,21 +36,27 @@
                 <div class="form-row">
                     <div class="user-edit-digest">
                         <div class="user-edit-digest">
-                            <label for="{{ form.email_digest_type.1.id_for_label }}" class="user-edit-digest-label">
-                                <i class="fas fa-envelope-open"></i>
-                                <span class="user-edit-digest-name">Дайджест каждый день<br><small style="display: inline-block; margin-top: 20px; line-height: 1.3em; color: #8A8A8A">+ гороскоп в подарок</small></span>
-                                {{  form.email_digest_type.1.tag }}
-                            </label>
-                            <label for="{{ form.email_digest_type.2.id_for_label }}" class="user-edit-digest-label">
-                                <i class="fas fa-calendar-week"></i>
-                                <span class="user-edit-digest-name">Только журнал раз в неделю</span>
-                                {{  form.email_digest_type.2.tag }}
-                            </label>
-                            <label for="{{ form.email_digest_type.0.id_for_label }}" class="user-edit-digest-label">
-                                <i class="fas fa-skull-crossbones"></i>
-                                <span class="user-edit-digest-name">Не надо писем</span>
-                                {{  form.email_digest_type.0.tag }}
-                            </label>
+                            <div class="user-edit-digest-item">
+                                {{ form.email_digest_type.1.tag }}
+                                <label for="{{ form.email_digest_type.1.id_for_label }}" class="user-edit-digest-label">
+                                    <i class="fas fa-envelope-open"></i>
+                                    <span class="user-edit-digest-name">Дайджест каждый день<br><small style="display: inline-block; margin-top: 20px; line-height: 1.3em; color: #8A8A8A">+ гороскоп в подарок</small></span>
+                                </label>
+                            </div>
+                            <div class="user-edit-digest-item">
+                                {{ form.email_digest_type.2.tag }}
+                                <label for="{{ form.email_digest_type.2.id_for_label }}" class="user-edit-digest-label">
+                                    <i class="fas fa-calendar-week"></i>
+                                    <span class="user-edit-digest-name">Только журнал раз в неделю</span>
+                                </label>
+                            </div>
+                            <div class="user-edit-digest-item">
+                                {{ form.email_digest_type.0.tag }}
+                                <label for="{{ form.email_digest_type.0.id_for_label }}" class="user-edit-digest-label">
+                                    <i class="fas fa-skull-crossbones"></i>
+                                    <span class="user-edit-digest-name">Не надо писем</span>
+                                </label>
+                            </div>
                         </div>
                     </div>
                     {% if form.email_digest_type.errors %}<span class="form-row-errors">{{ form.email_digest_type.errors }}</span>{% endif %}

--- a/frontend/html/users/intro.html
+++ b/frontend/html/users/intro.html
@@ -188,24 +188,30 @@
 
             <div class="form-row">
                 <div class="user-edit-digest">
-                    <label for="{{ form.email_digest_type.1.id_for_label }}" class="user-edit-digest-label">
-                        <i class="fas fa-envelope-open"></i>
-                        <span class="user-edit-digest-name">Ежедневные<br> обновления + журнал</span>
-                        <span class="user-edit-digest-description">Шлите мне всё!</span>
-                        {{  form.email_digest_type.1.tag }}
-                    </label>
-                    <label for="{{ form.email_digest_type.2.id_for_label }}" class="user-edit-digest-label">
-                        <i class="fas fa-calendar-week"></i>
-                        <span class="user-edit-digest-name">Журнал раз в неделю</span>
-                        <span class="user-edit-digest-description">Подборка отборного контента за неделю</span>
-                        {{  form.email_digest_type.2.tag }}
-                    </label>
-                    <label for="{{ form.email_digest_type.0.id_for_label }}" class="user-edit-digest-label">
-                        <i class="fab fa-telegram"></i>
-                        <span class="user-edit-digest-name">Онлайн в <a href="{{ settings.TELEGRAM_CLUB_CHANNEL_URL }}" target="_blank">телеграме</a></span>
-                        <span class="user-edit-digest-description">Не хочу никаких писем, сам подпишусь</span>
-                        {{  form.email_digest_type.0.tag }}
-                    </label>
+                    <div class="user-edit-digest-item">
+                        {{ form.email_digest_type.1.tag }}
+                        <label for="{{ form.email_digest_type.1.id_for_label }}" class="user-edit-digest-label">
+                            <i class="fas fa-envelope-open"></i>
+                            <span class="user-edit-digest-name">Ежедневные<br> обновления + журнал</span>
+                            <span class="user-edit-digest-description">Шлите мне всё!</span>
+                        </label>
+                    </div>
+                    <div class="user-edit-digest-item">
+                        {{ form.email_digest_type.2.tag }}
+                        <label for="{{ form.email_digest_type.2.id_for_label }}" class="user-edit-digest-label">
+                            <i class="fas fa-calendar-week"></i>
+                            <span class="user-edit-digest-name">Журнал раз в неделю</span>
+                            <span class="user-edit-digest-description">Подборка отборного контента за неделю</span>
+                        </label>
+                    </div>
+                    <div class="user-edit-digest-item">
+                        {{ form.email_digest_type.0.tag }}
+                        <label for="{{ form.email_digest_type.0.id_for_label }}" class="user-edit-digest-label">
+                            <i class="fab fa-telegram"></i>
+                            <span class="user-edit-digest-name">Онлайн в <a href="{{ settings.TELEGRAM_CLUB_CHANNEL_URL }}" target="_blank">телеграме</a></span>
+                            <span class="user-edit-digest-description">Не хочу никаких писем, сам подпишусь</span>
+                        </label>
+                    </div>
                 </div>
                 {% if form.email_digest_type.errors %}<span class="form-row-errors">{{ form.email_digest_type.errors }}</span>{% endif %}
             </div>

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1195,6 +1195,17 @@
             font-size: 17px;
         }
 
+            .user-edit-digest-item input {
+                display: inline-block;
+                visibility: hidden;
+                width: auto;
+                position: absolute;
+                padding-bottom: 10px;
+                bottom: 40px;
+                left: 50%;
+                transform: translate(-50%, -50%);
+            }
+
             .user-edit-digest-label {
                 display: block;
                 position: relative;
@@ -1211,6 +1222,15 @@
                 text-align: center;
             }
 
+            .user-edit-digest-item input:checked + .user-edit-digest-label {
+                background-color: var(--opposite-block-bg-color);
+                color: var(--opposite-text-color);
+            }
+
+            .user-edit-digest-item input:checked + .user-edit-digest-label a {
+                color: var(--opposite-text-color);
+            }
+
             .user-edit-digest-label:hover {
                 box-shadow: 2px 2px 8px 0 rgba(69, 70, 70, 0.12);
             }
@@ -1219,17 +1239,6 @@
                     display: block;
                     font-size: 60px;
                     padding-top: 20px;
-                }
-
-                .user-edit-digest-label input {
-                    display: inline-block;
-                    visibility: hidden;
-                    width: auto;
-                    position: absolute;
-                    padding-bottom: 10px;
-                    bottom: 40px;
-                    left: 50%;
-                    transform: translate(-50%, -50%);
                 }
 
                 .user-edit-digest-name {

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1196,14 +1196,8 @@
         }
 
             .user-edit-digest-item input {
-                display: inline-block;
                 visibility: hidden;
-                width: auto;
                 position: absolute;
-                padding-bottom: 10px;
-                bottom: 40px;
-                left: 50%;
-                transform: translate(-50%, -50%);
             }
 
             .user-edit-digest-label {

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1223,6 +1223,7 @@
 
                 .user-edit-digest-label input {
                     display: inline-block;
+                    visibility: hidden;
                     width: auto;
                     position: absolute;
                     padding-bottom: 10px;


### PR DESCRIPTION
Сейчас радиокнопки торчат прямо посередине блока-выбиралки и загораживают собой текст.
Если спрятать их через visibility: hidden — они по прежнему будут кликабельными, а текст будет красивым.

Вот так выглядит сейчас:
![Screenshot 2020-10-28 at 09 31 43](https://user-images.githubusercontent.com/430023/97401176-5ebc6a00-1901-11eb-83a9-2885da8d8e26.png)
