### PR TITLE
Get rid of postcss warning

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -774,7 +774,7 @@
         display: flex;
         flex-wrap: wrap;
         justify-content: center;
-        align-items: start;
+        align-items: flex-start;
     }
 
         .user-project {

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -137,7 +137,7 @@
         grid-row-start: 1;
         grid-row-end: 3;
         justify-self: start;
-        align-items: start;
+        align-items: flex-start;
     }
 
     .feed-post-votes {
@@ -146,7 +146,7 @@
         grid-row-start: 1;
         grid-row-end: 3;
         justify-self: end;
-        align-items: start;
+        align-items: flex-start;
     }
 
     .feed-post-header {
@@ -172,7 +172,7 @@
     display: grid;
     grid-template-columns: 200px auto;
     column-gap: 20px;
-    align-items: start;
+    align-items: flex-start;
 }
 
     @media only screen and (max-width : 570px) {
@@ -220,7 +220,7 @@
     grid-template-columns: minmax(auto, 1fr) min-content;
     grid-template-rows: auto auto auto;
     justify-content: stretch;
-    align-items: start;
+    align-items: flex-start;
 }
 
     .post-layout-block .post-upvote {
@@ -612,7 +612,7 @@
     grid-template-columns: 320px minmax(auto, 1fr);
     grid-template-rows: 90px 100px 500px auto;
     justify-content: stretch;
-    align-items: start;
+    align-items: flex-start;
     column-gap: 20px;
     row-gap: 20px;
 }


### PR DESCRIPTION
Closes #452

До:
```sh
webpack_1   |     WARNING in ./static/css/index.css (./node_modules/css-loader/dist/cjs.js??ref--0-1!./node_modules/postcss-loader/src!./static/css/index.css)
webpack_1   |     Module Warning (from ./node_modules/postcss-loader/src/index.js):
webpack_1   |     Warning
webpack_1   |     
webpack_1   |     (777:9) start value has mixed support, consider using flex-start instead
```

После: 
No more WARNING 👌