### PR TITLE
Lazy load Vue components (load them as chunks)

### DIFF
--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -3,29 +3,19 @@ import Vue from "vue";
 import "../css/index.css";
 
 import App from "./App.js";
-import PostUpvote from "./components/PostUpvote.vue";
-import PostBookmark from "./components/PostBookmark.vue";
-import PostSubscription from "./components/PostSubscription.vue";
-import CommentUpvote from "./components/CommentUpvote.vue";
-import UserTag from "./components/UserTag.vue";
-import PeopleMap from "./components/PeopleMap.vue";
-import SidebarToggler from "./components/SidebarToggler.vue";
-import UserExpertiseWindow from "./components/UserExpertiseWindow.vue";
-import UserAvatarInput from "./components/UserAvatarInput.vue";
-import StripeCheckoutButton from "./components/StripeCheckoutButton.vue";
 import ClubApi from "./common/api.service";
-import InputLengthCounter from "./components/InputLengthCounter.vue";
-Vue.component("post-upvote", PostUpvote);
-Vue.component("post-bookmark", PostBookmark);
-Vue.component("post-subscription", PostSubscription);
-Vue.component("comment-upvote", CommentUpvote);
-Vue.component("user-expertise-window", UserExpertiseWindow);
-Vue.component("user-tag", UserTag);
-Vue.component("people-map", PeopleMap);
-Vue.component("user-avatar-input", UserAvatarInput);
-Vue.component("sidebar-toggler", SidebarToggler);
-Vue.component("stripe-checkout-button", StripeCheckoutButton);
-Vue.component("input-length-counter", InputLengthCounter);
+
+Vue.component("post-upvote", () => import("./components/PostUpvote.vue"));
+Vue.component("post-bookmark", () => import("./components/PostBookmark.vue"));
+Vue.component("post-subscription", () => import("./components/PostSubscription.vue"));
+Vue.component("comment-upvote", () => import("./components/CommentUpvote.vue"));
+Vue.component("user-expertise-window", () => import("./components/UserExpertiseWindow.vue"));
+Vue.component("user-tag", () => import("./components/UserTag.vue"));
+Vue.component("people-map", () => import("./components/PeopleMap.vue"));
+Vue.component("user-avatar-input", () => import("./components/PostUpvote.vue"));
+Vue.component("sidebar-toggler", () => import("./components/SidebarToggler.vue"));
+Vue.component("stripe-checkout-button", () => import("./components/StripeCheckoutButton.vue"));
+Vue.component("input-length-counter", () => import("./components/InputLengthCounter.vue"));
 
 // Since our pages have user-generated content, any fool can insert "{{" on the page and break it.
 // We have no other choice but to completely turn off template matching and leave it on only for components.

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     context: __dirname,
     entry: path.join(__dirname, "static/js/main.js"),
     output: {
+        publicPath: "/static/dist/",
         path: path.join(__dirname, "static/dist"),
         filename: mode === "production" ? "[name]-[hash].js": "[name].js",
         libraryTarget: "var",


### PR DESCRIPTION
Fixes #450

Вот тут можно глянуть подробнее в чем разница [webpack-stats.zip](https://github.com/vas3k/vas3k.club/files/5465819/webpack-stats.zip).

Было:
- main.js 1.88 MB
![image](https://user-images.githubusercontent.com/11414342/97689116-cb6f6a00-1aa3-11eb-927c-9d654b6993d5.png)

Стало:
- main.js 1 MB (подробнее можно глянуть так 


![image](https://user-images.githubusercontent.com/11414342/97688754-4421f680-1aa3-11eb-854a-7cc61f48832e.png)


---

Что это вообще значит? 🤔

Грубо говоря, при таком подходе подгружается только то, что необходимо на данной страничке.

![vue-lazy-load-component](https://user-images.githubusercontent.com/11414342/97690337-86e4ce00-1aa5-11eb-99b7-37a2e1f93f06.gif)
Для наглядности 👆 я каждому чанку добавил кастомное название (например `Vue.component("post-upvote", () => import(/* webpackChunkName: "post-upvote" */"./components/PostUpvote.vue"));`), иначе они именуется как `0.js`, `1.js` и т.д.

---

В общем не знаю надо ли это или нет @vas3kу, но возможно будет хорошим примером как можно улучшить и оптимизировать загрузку бандла.

