### PR TITLE
Browserslist: caniuse-lite is outdated

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1077,9 +1077,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001048",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
-      "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg==",
+      "version": "1.0.30001154",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001154.tgz",
+      "integrity": "sha512-y9DvdSti8NnYB9Be92ddMZQrcOe04kcQtcxtBx4NkB04+qZ+JUWotnXBJTmxlKudhxNTQ3RRknMwNU2YQl/Org==",
       "dev": true
     },
     "chalk": {


### PR DESCRIPTION
```sh
webpack_1   | Browserslist: caniuse-lite is outdated. Please run:
webpack_1   | npx browserslist@latest --update-db
```

Updated to the latest version by running the command suggested above.