### PR TITLE
Prevent webfonts double-loading

### DIFF
--- a/frontend/static/css/fonts.css
+++ b/frontend/static/css/fonts.css
@@ -1,6 +1,8 @@
 @font-face {
     font-family: "Merriweather";
-    src: url("../webfonts/Merriweather-Italic.woff2") format("woff2"),
+    src: local('Merriweather Italic'),
+        local('Merriweather-Italic'),
+        url("../webfonts/Merriweather-Italic.woff2") format("woff2"),
         url("../webfonts/Merriweather-Italic.woff") format("woff");
     font-weight: normal;
     font-style: italic;
@@ -9,7 +11,9 @@
 
 @font-face {
     font-family: "Merriweather";
-    src: url("../webfonts/Merriweather-Black.woff2") format("woff2"),
+    src: local('Merriweather Black'),
+        local('Merriweather-Black'),
+        url("../webfonts/Merriweather-Black.woff2") format("woff2"),
         url("../webfonts/Merriweather-Black.woff") format("woff");
     font-weight: 900;
     font-style: normal;
@@ -18,7 +22,9 @@
 
 @font-face {
     font-family: "Merriweather";
-    src: url("../webfonts/Merriweather-Bold.woff2") format("woff2"),
+    src: local('Merriweather Bold'),
+        local('Merriweather-Bold'),
+        url("../webfonts/Merriweather-Bold.woff2") format("woff2"),
         url("../webfonts/Merriweather-Bold.woff") format("woff");
     font-weight: bold;
     font-style: normal;
@@ -27,7 +33,9 @@
 
 @font-face {
     font-family: "Merriweather";
-    src: url("../webfonts/Merriweather-Light.woff2") format("woff2"),
+    src: local('Merriweather Light'),
+        local('Merriweather-Light'),
+        url("../webfonts/Merriweather-Light.woff2") format("woff2"),
         url("../webfonts/Merriweather-Light.woff") format("woff");
     font-weight: 300;
     font-style: normal;
@@ -36,7 +44,10 @@
 
 @font-face {
     font-family: "Merriweather";
-    src: url("../webfonts/Merriweather-Regular.woff2") format("woff2"),
+    src: local('Merriweather'),
+        local('Merriweather Regular'),
+        local('Merriweather-Regular'),
+        url("../webfonts/Merriweather-Regular.woff2") format("woff2"),
         url("../webfonts/Merriweather-Regular.woff") format("woff");
     font-weight: normal;
     font-style: normal;
@@ -45,7 +56,10 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-Italic.woff2") format("woff2"), url("../webfonts/Ubuntu-Italic.woff") format("woff");
+    src: local('Ubuntu Italic'),
+        local('Ubuntu-Italic'),
+        url("../webfonts/Ubuntu-Italic.woff2") format("woff2"),
+        url("../webfonts/Ubuntu-Italic.woff") format("woff");
     font-weight: normal;
     font-style: italic;
     font-display: swap;
@@ -53,7 +67,9 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-BoldItalic.woff2") format("woff2"),
+    src: local('Ubuntu BoldItalic'),
+        local('Ubuntu-BoldItalic'),
+        url("../webfonts/Ubuntu-BoldItalic.woff2") format("woff2"),
         url("../webfonts/Ubuntu-BoldItalic.woff") format("woff");
     font-weight: bold;
     font-style: italic;
@@ -62,7 +78,10 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-Medium.woff2") format("woff2"), url("../webfonts/Ubuntu-Medium.woff") format("woff");
+    src: local('Ubuntu Medium'),
+        local('Ubuntu-Medium'),
+        url("../webfonts/Ubuntu-Medium.woff2") format("woff2"),
+        url("../webfonts/Ubuntu-Medium.woff") format("woff");
     font-weight: 500;
     font-style: normal;
     font-display: swap;
@@ -70,7 +89,10 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-Bold.woff2") format("woff2"), url("../webfonts/Ubuntu-Bold.woff") format("woff");
+    src: local('Ubuntu Bold'),
+        local('Ubuntu-Bold'),
+        url("../webfonts/Ubuntu-Bold.woff2") format("woff2"),
+        url("../webfonts/Ubuntu-Bold.woff") format("woff");
     font-weight: bold;
     font-style: normal;
     font-display: swap;
@@ -78,7 +100,10 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-Regular.woff2") format("woff2"), url("../webfonts/Ubuntu-Regular.woff") format("woff");
+    src: local('Ubuntu'),
+        local('Ubuntu Regular'),
+        local('Ubuntu-Regular'),
+        url("../webfonts/Ubuntu-Regular.woff2") format("woff2"), url("../webfonts/Ubuntu-Regular.woff") format("woff");
     font-weight: normal;
     font-style: normal;
     font-display: swap;
@@ -86,7 +111,9 @@
 
 @font-face {
     font-family: "Ubuntu";
-    src: url("../webfonts/Ubuntu-MediumItalic.woff2") format("woff2"),
+    src: local('Ubuntu MediumItalic'),
+        local('Ubuntu-MediumItalic'),
+        url("../webfonts/Ubuntu-MediumItalic.woff2") format("woff2"),
         url("../webfonts/Ubuntu-MediumItalic.woff") format("woff");
     font-weight: 500;
     font-style: italic;


### PR DESCRIPTION
The `local()` function allows users to use their local copy of the font if present instead of downloading it.


Before:
![image](https://user-images.githubusercontent.com/11414342/103300446-8e721600-4a07-11eb-9d86-ce5d8746c98a.png)

After: 
![image](https://user-images.githubusercontent.com/11414342/103300466-9631ba80-4a07-11eb-8b9a-1ebc9005c418.png)
