### PR TITLE
Added text-shadow for counter in people map

### DIFF
--- a/frontend/static/css/components/people.css
+++ b/frontend/static/css/components/people.css
@@ -57,6 +57,7 @@
         background-color: var(--block-bg-color);
         border: solid 2px var(--block-bg-color);
         color: #FFF;
+        text-shadow: 0 0 2px black;
         text-align: center;
         font-weight: 700;
         font-size: 12px;


### PR DESCRIPTION
Добавил тень для текста по мотивам ишака #478 
Теперь на светлом фоне каунтер читается без проблем
![image](https://user-images.githubusercontent.com/6443205/103468095-4aac4300-4d5e-11eb-848f-d6413c88a081.png)

