### PR TITLE
Turning on a native browser spell-checker

### DIFF
--- a/frontend/static/js/App.js
+++ b/frontend/static/js/App.js
@@ -36,10 +36,11 @@ const imageUploadOptions = {
 const defaultMarkdownEditorOptions = {
     autoDownloadFontAwesome: false,
     spellChecker: false,
+    nativeSpellcheck: true,
     forceSync: true,
     status: false,
-    inputStyle: "textarea",
-    tabSize: 4
+    inputStyle: "contenteditable",
+    tabSize: 4,
 };
 
 /**


### PR DESCRIPTION
В соответсвии с https://github.com/Ionaru/easy-markdown-editor/pull/143 и как описано в документации
![image](https://user-images.githubusercontent.com/11414342/103760603-fc2ccc00-501d-11eb-9963-c6b44ddce6fa.png)


Closes #486 
