### PR TITLE
Фича: Более светлый фон для новых коментариев в темной теме.

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1972,7 +1972,7 @@
     }
 
 .comment-is-new {
-    background-color: rgba(104, 118, 128, 0.15);
+    background-color: rgba(104, 118, 128, 0.30);
 }
 
 .user-telegram-auth-data {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28477031/104052975-300d1a80-51f3-11eb-940c-94faa2f4e75c.png)
Измененный вариант справа. 
Делает более заметными новые комменты в длинной простыне.