### PR TITLE
Fix unwanted scroll on linked post block

### DIFF
--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -799,7 +799,7 @@
     .linked-posts-scroll {
         display: block;
         overflow-x: visible;
-        overflow-y: scroll;
+        overflow-y: auto;
         width: 100%;
         max-height: 520px;
         padding: 30px 30px 30px 5px;


### PR DESCRIPTION
Removes scroll, when it's not needed.

![CleanShot 2021-01-18 at 21 29 21](https://user-images.githubusercontent.com/654597/104960535-b3d5bc80-59d4-11eb-8830-c68dfe383cb7.png)
