### PR TITLE
Stripe login fixes

### DIFF
--- a/auth/views/email.py
+++ b/auth/views/email.py
@@ -44,7 +44,7 @@ def email_login(request):
         return set_session_cookie(response, user, session)
     else:
         # email/nickname login
-        user = User.objects.filter(Q(email=email_or_login.lower()) | Q(slug=email_or_login)).first()
+        user = User.objects.filter(Q(email=email_or_login.lower()) | Q(slug__iexact=email_or_login)).first()
         if not user:
             return render(request, "error.html", {
                 "title": "Такого юзера нет 🤔",

--- a/notifications/telegram/users.py
+++ b/notifications/telegram/users.py
@@ -81,5 +81,5 @@ def notify_user_auth(user, code):
     if user.telegram_id:
         send_telegram_message(
             chat=Chat(id=user.telegram_id),
-            text=f"<b>{code.code}</b> — ваш одноразовый код для входа в Клуб"
+            text=f"<code>{code.code}</code> — ваш одноразовый код для входа в Клуб"
         )


### PR DESCRIPTION
Два небольших улучшения для логина по нику:

1) Код для телеги теперь моноширный, так в андроидных клиентах его можно скопировать одним тапом (насчет яблочных не знаю)
2) Логин по нику теперь не чувствителен к регистру ника