### PR TITLE
Fix paginator-page background for long page numbers

### DIFF
--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -80,7 +80,8 @@
 
     .paginator-page {
         display: inline-block;
-        width: 30px;
+        min-width: 30px;
+        width: auto;
         height: 30px;
         text-align: center;
         line-height: 30px;


### PR DESCRIPTION
## Before:
paginator-page has incorrect background for long page numbers (i.e. 100) due to the fixed width.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/4790464/106587534-67e95280-6552-11eb-809f-9f27eeaeb1dc.png">

## After:

<img width="789" alt="image" src="https://user-images.githubusercontent.com/4790464/106587911-da5a3280-6552-11eb-872d-acc5565f3594.png">

Env: Latest Safari and Firefox on macOS 11.x