### PR TITLE
Added link to telegram renderer

### DIFF
--- a/common/markdown/plain_renderer.py
+++ b/common/markdown/plain_renderer.py
@@ -3,7 +3,10 @@ import mistune
 
 class PlainRenderer(mistune.HTMLRenderer):
     def link(self, link, text=None, title=None):
-        return "[" + (text or link) + "]"
+        if text:
+            return f'[{text}]({link})'
+        else:
+            return f'({link})'
 
     def image(self, src, alt="", title=None):
         return "🖼"


### PR DESCRIPTION
Сейчас все уведомления в телеге затирают ссылку если в маркдауне ссылка была спрятана за текстом, приходилось открывать комментарий чтобы посмотреть на ссылку, это неудобно.
<img width="338" alt="Screenshot 2021-02-03 114809" src="https://user-images.githubusercontent.com/16938543/106721461-c0355880-6615-11eb-8001-df096e2a4491.png">

В идеале было бы сделать с помощью нативной ссылки в телеграме, но там дальше по коду все html теги обрезаются, не хотел сильно ломать эту логику. 

