### PR TITLE
фикс #466 "..при выборе тэгов из разных блоков при переходе на следующую страницу отваливается тег"

### DIFF
--- a/posts/templatetags/query_params.py
+++ b/posts/templatetags/query_params.py
@@ -9,5 +9,14 @@ register = template.Library()
 @register.simple_tag(takes_context=True)
 def append_query_param(context, **kwargs):
     query_params = deepcopy(context.request.GET.dict())
+    query_params_tags = context.request.GET.getlist("tags")
     query_params.update(kwargs)
+
+    query_params_for_urlencode = []
+    for index, key in enumerate(query_params):
+        if key != "tags":
+            query_params_for_urlencode.append((key, query_params[key]))
+    for tag in query_params_tags:
+        query_params_for_urlencode.append(('tags', tag))
+
     return "?" + urlencode(query_params)


### PR DESCRIPTION
Из [документации к urlencode](https://docs.python.org/3.8/library/urllib.parse.html#urllib.parse.urlencode)  _Convert a mapping object or a sequence of two-element tuples, which may contain str or bytes objects, to a percent-encoded ASCII text string._
`>>> urlencode([('var', 'earth'), ('var', 'wind')]) 
'var=earth&var=wind'`
Нашел [здесь](https://stackoverflow.com/a/28492562)