### PR TITLE
 fix /people/ page pagination with multiple tags: removed the disappearance of parameters

### DIFF
--- a/posts/templatetags/query_params.py
+++ b/posts/templatetags/query_params.py
@@ -8,6 +8,7 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def append_query_param(context, **kwargs):
-    query_params = deepcopy(context.request.GET.dict())
-    query_params.update(kwargs)
-    return "?" + urlencode(query_params)
+    query_params = deepcopy(context.request.GET)
+    for param,value in kwargs.items():
+        query_params[param] = value
+    return "?" + query_params.urlencode()


### PR DESCRIPTION
Пример:
на странице https://vas3k.club/people/?query=&country=&tags=work-hard&tags=extrovert ссылка на следующую страницу содержит только один тэг
`<a href="?query=&amp;country=&amp;tags=extrovert&amp;page=2" class="paginator-page ">2</a>`