### PR TITLE
Fix #413: prevent intro edit from hiding on mobiles

### DIFF
--- a/frontend/html/common/menu-full.html
+++ b/frontend/html/common/menu-full.html
@@ -17,7 +17,7 @@
     <div class="menu-right">
         {% if me %}
             {% if me.is_club_member %}
-                <a href="{% url "compose" %}" class="button menu-button menu-button-compose"><i class="fas fa-pen"></i><span class="compose-text">&nbsp;&nbsp;Пиши</span></a>
+                <a href="{% url "compose" %}" class="button menu-button menu-button-compose"><i class="fas fa-pen"></i><span class="compose-btn-text">&nbsp;&nbsp;Пиши</span></a>
                 <a href="{% url "bookmarks" %}" class="menu-button menu-button-bookmark"><i class="fa fa-bookmark"></i>&nbsp;&nbsp;</a>
             {% endif %}
             <a href="{% url "profile" me.slug %}" class="avatar menu-avatar"><img src="{{ me.get_avatar }}" alt="Аватар {{ me.full_name }}" /></a>

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1526,7 +1526,7 @@
             font-size: 80%;
         }
 
-        .compose-text {
+        .compose-btn-text {
             display: none;
         }
     }


### PR DESCRIPTION
#413 annoys me greatly so I decided to look at least for a quick fix that I can implement and make my mobile experience better.

The bug has been introduced in #372. PR author intention was hiding "Пиши" button caption on narrow screens but accidentally he used the same class name that is being used on a [div wrapper](https://github.com/vas3k/vas3k.club/blob/master/frontend/html/posts/compose/intro.html#L11) in [all](https://github.com/vas3k/vas3k.club/blob/master/frontend/html/posts/compose/link.html#L30) [post create/edit templates](https://github.com/vas3k/vas3k.club/blob/master/frontend/html/posts/compose/idea.html#L29).

Class name update seems to solve the issue
![image](https://user-images.githubusercontent.com/153191/108746256-d20c7a80-7587-11eb-8c7f-fd4bf9108c0e.png)

**UPD**
"Пиши" caption remains hidden on mobiles
![image](https://user-images.githubusercontent.com/153191/108746459-1566e900-7588-11eb-8581-a795848efbdb.png)
