### PR TITLE
Добавил allow-атрибуты в ютубовский встраиваемый плеер

### DIFF
--- a/common/markdown/club_renderer.py
+++ b/common/markdown/club_renderer.py
@@ -64,7 +64,9 @@ class ClubRenderer(mistune.HTMLRenderer):
         video_tag = (
             f'<span class="ratio-16-9">'
             f'<iframe loading="lazy" src="https://www.youtube.com/embed/{escape_html(youtube_match.group(1))}'
-            f'?autoplay=0&amp;controls=1&amp;showinfo=1&amp;vq=hd1080" frameborder="0"></iframe>'
+            f'?autoplay=0&amp;controls=1&amp;showinfo=1&amp;vq=hd1080"'
+            f'allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"'
+            f'allowfullscreen></iframe>'
             f"</span>"
         )
         caption = f"<figcaption>{escape_html(title)}</figcaption>" if title else ""

--- a/frontend/html/posts/embeds/youtube.html
+++ b/frontend/html/posts/embeds/youtube.html
@@ -1,5 +1,5 @@
 {% if src %}
 <span class="ratio-16-9">
-    <iframe src="https://www.youtube.com/embed/{{ src }}?autoplay=0&amp;controls=1&amp;showinfo=1&amp;vq=hd1080" frameborder="0"></iframe>
+    <iframe loading="lazy" src="https://www.youtube.com/embed/{{ src }}?autoplay=0&amp;controls=1&amp;showinfo=1&amp;vq=hd1080" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen" allowfullscreen></iframe>
 </span>
 {% endif %}


### PR DESCRIPTION
Сначала хотел добавить только `allowfullscreen` (ибо бесит, что нельзя видосы открыть на фуллскрин), а потом решил докинуть и остальное, что предлагает стандартно сам ютуб, когда хочешь встроить видео с него куда-то.

![image](https://user-images.githubusercontent.com/18071040/119396583-78cef700-bcee-11eb-8aef-e44857e42b58.png)
