### PR TITLE
removed position absolute from big-radio-label class

### DIFF
--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -720,9 +720,6 @@ img.emoji {
 
     .big-radio-label {
         display: block;
-        position: absolute;
-        top: 0;
-        left: 0;
         width: 100%;
         height: 100%;
         margin: 10px;


### PR DESCRIPTION
убрал абсолют с `.big-radio-label`, а то в мобильной версии текст выезжал. использовалось вроде только в трех местах, вот сравнение до и после:

| До | После |
--- | --- 
|.<img width="311" alt="Screen Shot 2021-06-02 at 10 02 44" src="https://user-images.githubusercontent.com/9719319/120438891-8ccbc600-c38a-11eb-8336-00d82d84e64d.png"> | <img width="311" alt="Screen Shot 2021-06-02 at 10 02 55" src="https://user-images.githubusercontent.com/9719319/120438941-9ce3a580-c38a-11eb-813f-748012591b93.png"> |
| <img width="311" alt="Screen Shot 2021-06-02 at 10 01 56" src="https://user-images.githubusercontent.com/9719319/120439022-b5ec5680-c38a-11eb-9c37-14d7bc8c82c6.png"> | <img width="311" alt="Screen Shot 2021-06-02 at 10 03 10" src="https://user-images.githubusercontent.com/9719319/120439051-bdabfb00-c38a-11eb-9ca5-8314fa116ebb.png"> |
| <img width="311" alt="Screen Shot 2021-06-02 at 10 01 26" src="https://user-images.githubusercontent.com/9719319/120439091-cbfa1700-c38a-11eb-8c84-ec7db3ef1457.png"> | <img width="311" alt="Screen Shot 2021-06-02 at 10 03 25" src="https://user-images.githubusercontent.com/9719319/120439112-d3212500-c38a-11eb-9d46-1e01374cfeb6.png"> |

