### PR TITLE
fix some telegram admins notifications

### DIFF
--- a/notifications/telegram/users.py
+++ b/notifications/telegram/users.py
@@ -71,19 +71,17 @@ def notify_user_ping(user, message):
 
 
 def notify_admin_user_ping(user, message):
-    if user.telegram_id:
-        send_telegram_message(
-            chat=ADMIN_CHAT,
-            text=f"🛎 <b>Юзера {user.slug} пинганули:</b> {message}"
-        )
+    send_telegram_message(
+        chat=ADMIN_CHAT,
+        text=f"🛎 <b>Юзера {user.slug} пинганули:</b> {message}"
+    )
 
 
 def notify_admin_user_unmoderate(user):
-    if user.telegram_id:
-        send_telegram_message(
-            chat=ADMIN_CHAT,
-            text=f"💣 <b>Юзера {user.slug} размодерировали</b>"
-        )
+    send_telegram_message(
+        chat=ADMIN_CHAT,
+        text=f"💣 <b>Юзера {user.slug} размодерировали</b>"
+    )
 
 
 def notify_user_auth(user, code):


### PR DESCRIPTION
Небольшой фикс уведомлений в админ-чат о письме пользователю от модератора и о размодерировании.

Суть фикса в том, что уведомления направляются в `ADMIN_CHAT`, но стояли за if'ом на наличие привязанного бота у юзера, который я и убрал (из-за if'а не все уведомления попадали в админ-чат).