### PR TITLE
Скроллинг комментариев кнопками ctrl-up/down #662

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -446,6 +446,20 @@
     }
 
 
+@keyframes commentHighlight {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.comment-scroll-selected {
+    animation: commentHighlight 0.3s ease-in-out forwards;
+}
+
+
 .comment-layout-normal {
     display: grid;
     grid-template-columns: 60px minmax(auto, 1fr) 60px;


### PR DESCRIPTION
### Скроллинг комментариев кнопками ctrl-up/down #662

На macOS - shift-ctrl-up/down. Потому что Mission Control.

Кажется, получилось попроще, чем на той же Лепре. Без внешних библиотек и Javascript посовременнее.

При скачке элемент фокуса моргает прозрачностью треть секунды.

Safari скачет без анимаций, т.к. не умеет в `behavior: "smooth"`.
Можно исправить полифилом https://github.com/iamdustan/smoothscroll

Но кажется, полифил будет лишним.

https://user-images.githubusercontent.com/3754755/129095582-9d1902cb-904f-41cb-bd84-30aa327dc498.mp4
