### PR TITLE
Fixing issue #667

### DIFF
--- a/common/url_metadata_parser.py
+++ b/common/url_metadata_parser.py
@@ -21,7 +21,7 @@ requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
 log = logging.getLogger(__name__)
 
 
-ParsedURL = namedtuple("ParsedURL", ["url", "domain", "title", "favicon", "summary", "image"])
+ParsedURL = namedtuple("ParsedURL", ["url", "domain", "title", "favicon", "summary", "image", "description"])
 
 
 def parse_url_preview(url: str) -> Optional[ParsedURL]:
@@ -44,6 +44,7 @@ def parse_url_preview(url: str) -> Optional[ParsedURL]:
         favicon=strip_tags(urljoin(article.url, article.meta_favicon)),
         summary="",
         image=article.top_image,
+        description=article.meta_description,
     )
 
 

--- a/frontend/html/posts/embeds/summary.html
+++ b/frontend/html/posts/embeds/summary.html
@@ -8,9 +8,11 @@
                 <img src="{{ post.metadata.image }}" alt="{{ post.title }}" class="post-link-image">
             {% endif %}
 
+            {% if post.metadata.title or post.metadata.description %}
             <span class="post-link-title">
-                {{  post.metadata.title }}
+                {{  post.metadata.title|default:post.metadata.description }}
             </span>
+            {% endif %}
 
             <span class="post-link-url">
                 {{ post.metadata.url|truncatechars:"80" }}

--- a/posts/templatetags/posts.py
+++ b/posts/templatetags/posts.py
@@ -72,7 +72,7 @@ summary_template = loader.get_template("posts/embeds/summary.html")
 
 @register.simple_tag()
 def link_summary(post):
-    if not post.metadata or not post.metadata.get("title") or not post.metadata.get("url"):
+    if not post.metadata or not any(map(post.metadata.get, ['title', 'url', 'description'])):
         return ""
 
     embed = ""


### PR DESCRIPTION
Проблема вызвана кривым кодом в библиотек newspaper3k, который не очень корректно обрабатывает title из одних только русских символов (точнее комбинация двух ошибок, в extractors.py:289 и extractors.py:347).
Можно было бы починить библиотеку, но она не выглядит активной.
Предлагается сразу два фикса:
1) сохранять дополнительно meta_description из newspaper.Article. Если title пустой, а description нет - использовать его.
2) если оба пустые, показывать просто урл.

Для конкретный ссылки из бага, будет выглядеть так:
![image](https://user-images.githubusercontent.com/2089015/129980963-0f9a5fb4-a9c1-4bec-a7be-b4568ad6c546.png)

Существующие ссылки естественно автоматом не будут обновлены, репортер бага должен будет пересохранить пост.