### PR TITLE
[feature] Скроллинг по непрочитанным комментариям + кнопка «наверх»

### DIFF
--- a/common/markdown/club_renderer.py
+++ b/common/markdown/club_renderer.py
@@ -70,7 +70,7 @@ class ClubRenderer(mistune.HTMLRenderer):
         if title in IMAGE_CSS_CLASSES:
             css_classes = IMAGE_CSS_CLASSES[title]
 
-        image_tag = f'<img loading="lazy" src="{escape_html(src)}" alt="{escape_html(title)}">'
+        image_tag = f'<img src="{escape_html(src)}" alt="{escape_html(title)}">'
         caption = f"<figcaption>{escape_html(title)}</figcaption>" if title else ""
         return f'<figure class="{css_classes}">{image_tag}{caption}</figure>'
 

--- a/frontend/html/layout.html
+++ b/frontend/html/layout.html
@@ -45,7 +45,7 @@
 {% endblock %}
 
 {% block footer %}
-    <footer class="footer">
+    <footer class="footer" id="footer">
         <div class="footer-left">
             <a href="{% url "docs" "about" %}">О Клубе</a> &nbsp;&middot;&nbsp;
 

--- a/frontend/html/posts/show/layout.html
+++ b/frontend/html/posts/show/layout.html
@@ -37,6 +37,10 @@
     <div class="content">
         {% block comments %}
             <div class="post-comments" id="comments">
+                <div class="comment-scroll-arrow-wrapper">
+                    <comment-scroll-arrow />
+                </div>
+
                 <div class="post-comments-title">
                     <div class="post-comments-title-left">
                         {% if post.comment_count > 0 %}

--- a/frontend/html/posts/show/layout.html
+++ b/frontend/html/posts/show/layout.html
@@ -41,7 +41,7 @@
                     <comment-scroll-arrow />
                 </div>
 
-                <div class="post-comments-title">
+                <div class="post-comments-title" id="post-comments-title">
                     <div class="post-comments-title-left">
                         {% if post.comment_count > 0 %}
                             <a href="#comments" class="post-comments-count">

--- a/frontend/html/posts/show/layout.html
+++ b/frontend/html/posts/show/layout.html
@@ -82,7 +82,7 @@
                 {% endif %}
 
                 {% if me and post.is_commentable and post.is_visible or me.is_moderator %}
-                    <div class="post-comments-form">
+                    <div class="post-comments-form" id="post-comments-form">
                         {% include "comments/forms/comment.html" with post=post form=comment_form %}
                     </div>
 

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1168,7 +1168,8 @@
     }
 }
 
-.comment-scroll-animation {
+.comment.comment-scroll-animation,
+.reply.comment-scroll-animation {
     animation: commentHighlight 0.3s ease-in-out forwards;
 }
 

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1157,3 +1157,53 @@
         width: 80px;
         height: 80px;
     }
+
+@keyframes commentHighlight {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+.comment-scroll-selected {
+    animation: commentHighlight 0.3s ease-in-out forwards;
+}
+
+.comment-scroll-arrow {
+    position: fixed;
+    left: 20px;
+    bottom: 20px;
+    display: inline-block;
+    text-decoration: none;
+    width: 48px;
+    height: 48px;
+    font-size: 140%;
+    font-weight: 600;
+    font-family: var(--sans-font);
+    color: var(--text-color);
+    border: var(--button-border);
+    border-radius: var(--button-border-radius);
+    cursor: pointer;
+    z-index: 5;
+}
+
+    .comment-scroll-arrow:hover {
+        background-color: var(--opposite-bg-color);
+        color: var(--opposite-text-color);
+    }
+
+    .comment-scroll-arrow::before {
+        content: "▲";
+        position: absolute;
+        font-size: 18px;
+        top: 50%;
+        left: 50%;
+        transform: translateX(-50%) translateY(-50%) rotate(180deg);
+        transition: transform .2s;
+    }
+
+    .comment-scroll-arrow.arrow-up::before {
+        transform: translateX(-50%) translateY(-50%) rotate(0);
+    }

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -1047,6 +1047,7 @@
         display: flex;
         flex-direction: row;
         justify-content: space-between;
+        scroll-margin-top: 20px;
     }
 
     .post-comments-count {
@@ -1167,7 +1168,7 @@
     }
 }
 
-.comment-scroll-selected {
+.comment-scroll-animation {
     animation: commentHighlight 0.3s ease-in-out forwards;
 }
 

--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -162,8 +162,8 @@
     scroll-margin-top: 20px;
 }
 
-    .comment:target,
-    .reply:target {
+    .comment:not(.comment-scroll-selected):target,
+    .reply:not(.comment-scroll-selected):target {
         background-color: rgba(125, 232, 125, 0.3);
     }
 

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -445,21 +445,6 @@
         align-self: start;
     }
 
-
-@keyframes commentHighlight {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-.comment-scroll-selected {
-    animation: commentHighlight 0.3s ease-in-out forwards;
-}
-
-
 .comment-layout-normal {
     display: grid;
     grid-template-columns: 60px minmax(auto, 1fr) 60px;

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -4,10 +4,6 @@
     --normal-content-width: 800px;
 }
 
-html {
-    scroll-behavior: smooth; 
-}
-
 .menu {
     display: grid;
     max-width: var(--max-content-width);

--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -4,6 +4,10 @@
     --normal-content-width: 800px;
 }
 
+html {
+    scroll-behavior: smooth; 
+}
+
 .menu {
     display: grid;
     max-width: var(--max-content-width);

--- a/frontend/static/js/App.js
+++ b/frontend/static/js/App.js
@@ -86,7 +86,6 @@ const App = {
     onMount() {
         this.initializeImageZoom();
         this.initializeEmojiForPoorPeople();
-        this.initializeCommentScroll();
         this.blockCommunicationFormsResubmit();
 
         const registeredEditors = this.initializeMarkdownEditor();
@@ -265,62 +264,6 @@ const App = {
             cubicBezier: "cubic-bezier(.2, 0, .1, 1)",
             background: "rgba(0, 0, 0, .4)",
             zIndex: 1e6,
-        });
-    },
-    initializeCommentScroll() {
-        const scrollExtreme = (direction) => {
-            if (direction === "Down") {
-                window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
-            } else {
-                window.scrollTo({ top: 0, behavior: "smooth" });
-            }
-        };
-
-        document.addEventListener('keyup', (e) => {
-            // ctrl-up/down для всех, а в macos - ⇧⌃↑/↓
-            if (!e.ctrlKey || ["ArrowDown", "ArrowUp", "Down", "Up"].indexOf(e.key) < 0) {
-                return;
-            }
-
-            e.preventDefault();
-            const direction = e.key.replace(/^Arrow/, "");
-
-            let comments = document.querySelectorAll(".comment-is-new");
-            if (comments.length < 1) {
-                comments = document.querySelectorAll(".comment");
-            }
-            if (comments.length < 1) {
-                // Без комментариев
-                return scrollExtreme(direction);
-            }
-
-            const position = window.scrollY + window.innerHeight / 2;
-            const bodyTop = document.body.getBoundingClientRect().top;
-
-            // Убираем комментарии ниже или выше направления поиска
-            const filteredComments = [...comments].filter((el) => {
-                const elBCR = el.getBoundingClientRect();
-                const eltop = elBCR.top - bodyTop;
-                return (direction === "Down") ?
-                    eltop - elBCR.height / 2 > position
-                    : eltop + elBCR.height / 2 < position;
-            });
-            if (filteredComments.length < 1) {
-                return scrollExtreme(direction);
-            }
-
-            // Находим ближайший к середине экрана комментарий
-            const nearest = [...filteredComments].reduce((a, b) => {
-                const atop = a.getBoundingClientRect().top - bodyTop;
-                const btop = b.getBoundingClientRect().top - bodyTop;
-                return Math.abs(btop - position) < Math.abs(atop - position) ? b : a;
-            });
-            window.scrollTo({
-                top: nearest.getBoundingClientRect().top - bodyTop - window.innerHeight / 2,
-                behavior: "smooth" // Safari работает без анимации
-            });
-            nearest.classList.add("comment-scroll-selected");
-            window.setTimeout(() => { nearest.classList.remove("comment-scroll-selected"); }, 500);
         });
     },
     blockCommunicationFormsResubmit() {

--- a/frontend/static/js/common/utils.js
+++ b/frontend/static/js/common/utils.js
@@ -18,3 +18,24 @@ export const pluralize = (count, words) => {
     const cases = [2, 0, 1, 1, 1, 2];
     return words[ (count % 100 > 4 && count % 100 < 20) ? 2 : cases[ Math.min(count % 10, 5)] ];
 }
+
+export const throttle = (fn, wait) => {
+    let inThrottle, lastFn, lastTime;
+    return function () {
+        const context = this,
+            args = arguments;
+        if (!inThrottle) {
+            fn.apply(context, args);
+            lastTime = Date.now();
+            inThrottle = true;
+        } else {
+            clearTimeout(lastFn);
+            lastFn = setTimeout(function () {
+                if (Date.now() - lastTime >= wait) {
+                    fn.apply(context, args);
+                    lastTime = Date.now();
+                }
+            }, Math.max(wait - (Date.now() - lastTime), 0));
+        }
+    };
+}

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -25,48 +25,43 @@ export default {
         getBodyTop() {
             return document.body.getBoundingClientRect().top;
         },
-        scrollTo(offset, callback) {
-            const fixedOffset = offset.toFixed();
-            const onScroll = () => {
-                if (window.pageYOffset.toFixed() === fixedOffset) {
-                    window.removeEventListener('scroll', onScroll);
-                    if (callback) {
-                        callback();
-                    }
-                }
-            };
+        scrollTo(elementId, callback) {
+            document.location.hash = `#${elementId}`;
 
-            window.addEventListener('scroll', onScroll);
-            onScroll();
-            window.scrollTo({
-                top: offset,
-                behavior: 'smooth'
-            });
+            // TODO: callback call after document.location scroll end
+            if (callback) {
+                callback();
+            }
         },
         scrollExtreme(direction) {
-            const downTarget = document.querySelector(".comment-form");
-            const bodyTop = this.getBodyTop();
+            document.location.hash = '';
 
             if (direction === "Down") {
                 this.arrowDirection = "Up";
-                this.scrollTo(downTarget.getBoundingClientRect().top - bodyTop - this.commentMargin);
+
+                document.location.hash = '#post-comments-form';
             } else {
                 this.arrowDirection = "Down";
-                this.scrollTo(0);
+
+                window.scrollTo({
+                    top: 0,
+                    behavior: 'smooth'
+                });
             }
         },
         scrollToComment(direction) {
             let comments = document.querySelectorAll(".comment-is-new");
+
             const bodyTop = this.getBodyTop();
 
             if (comments.length < 1) {
                 // take only the first comment
-                const fistComment = document.querySelector(".comment");
-                comments = fistComment ? [fistComment] : [];
+                const commentBlock = document.getElementById("comments");
+                comments = commentBlock ? [commentBlock] : [];
             }
 
             if (comments.length < 1) {
-                // Без комментариев
+                // Then post without comments
                 return this.scrollExtreme(direction);
             }
 
@@ -96,7 +91,7 @@ export default {
                 window.setTimeout(() => { nearest.classList.remove("comment-scroll-selected"); }, 500);
             };
 
-            this.scrollTo(nearest.getBoundingClientRect().top - bodyTop - this.commentMargin, highlightComment);
+            this.scrollTo(nearest.id, highlightComment);
         },
         onArrowClickHandler() {
             if (this.arrowDirection == "Up") {

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -36,7 +36,7 @@ export default {
                 document.location.hash = '';
             }
 
-            // document.documentElement.style.scrollBehavior = "smooth";
+            document.documentElement.style.scrollBehavior = "smooth";
 
             const offset = el.getBoundingClientRect().top - this.getBodyTop() - this.getElementMargin(el);
 
@@ -44,7 +44,7 @@ export default {
                 if (Math.abs(offset - window.pageYOffset) < 1) {
                     window.removeEventListener('scroll', onScroll);
 
-                    // document.documentElement.style.scrollBehavior = "auto";
+                    document.documentElement.style.scrollBehavior = "auto";
 
                     if (callback) {
                         callback();

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -64,7 +64,10 @@ export default {
             if (direction === "Down") {
                 this.arrowDirection = "Up";
 
-                const downTarget = document.getElementById("post-comments-form");
+                const postCommentsForm = document.getElementById("post-comments-form");
+                const footer = document.getElementById("footer");
+
+                const downTarget = postCommentsForm || footer;
                 this.scrollToElement(downTarget);
             } else {
                 this.arrowDirection = "Down";
@@ -94,16 +97,14 @@ export default {
             const bodyTop = this.getBodyTop();
 
             if (comments.length < 1) {
-                /**
-                 * take comments header, do not use the #comments id
-                 * because it will not work in filteredComments because of the height
-                 * also be careful to change scroll-margin-top css of .post-comments-title class (same reason)
-                 */
-                const commentBlock = document.getElementById("post-comments-title");
+                // take comments header
+                const commentBlock = document.getElementById("comments");
                 const commentBlockArray = commentBlock ? [commentBlock] : [];
 
                 // Новых нет, перебираем прочтённые комментарии
-                comments = [...commentBlockArray, ...document.querySelectorAll(".comment")];
+                const oldComments = document.querySelectorAll(".comment");
+
+                comments = oldComments.length > 0 ? [...commentBlockArray, ...document.querySelectorAll(".comment")] : [];
             }
 
             if (comments.length < 1) {

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -110,7 +110,7 @@ export default {
                 const elTop = el.getBoundingClientRect().top;
                 const elTopMargin = this.getElementMargin(el);
 
-                return (direction === "Down") ? elTop - elTopMargin > 1 : elTop < 0;
+                return (direction === "Down") ? elTop - elTopMargin > 2 : elTop < 0;
             });
 
             if (filteredComments.length < 1) {

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -1,0 +1,150 @@
+<template>
+    <span
+        class="comment-scroll-arrow"
+        :class="{
+            'arrow-up': arrowDirection === 'Up'
+        }"
+        @click.prevent="onArrowClickHandler"
+    >
+    </span>
+</template>
+
+<script>
+import { throttle } from "../common/utils.js";
+
+export default {
+    name: "CommentScrollArrow",
+    data() {
+        return {
+            arrowDirection: "Down",
+            scrollThrottleDelay: 150,
+        };
+    },
+    methods: {
+        getBodyTop() {
+            return document.body.getBoundingClientRect().top;
+        },
+        scrollTo(offset, callback) {
+            const fixedOffset = offset.toFixed();
+            const onScroll = () => {
+                if (window.pageYOffset.toFixed() === fixedOffset) {
+                    window.removeEventListener('scroll', onScroll);
+                    callback();
+                }
+            };
+
+            window.addEventListener('scroll', onScroll);
+            onScroll();
+            window.scrollTo({
+                top: offset,
+                behavior: 'smooth'
+            });
+        },
+        scrollExtreme(direction) {
+            const downTarget = document.querySelector(".comment-form");
+            const bodyTop = this.getBodyTop();
+
+            if (direction === "Down") {
+                this.arrowDirection = "Up";
+                this.scrollTo(downTarget.getBoundingClientRect().top - bodyTop - window.innerHeight / 2);
+            } else {
+                this.arrowDirection = "Down";
+                this.scrollTo(0);
+            }
+        },
+        scrollToComment(direction) {
+            let comments = document.querySelectorAll(".comment-is-new");
+            const bodyTop = this.getBodyTop();
+
+            if (comments.length < 1) {
+                // Без комментариев
+                return this.scrollExtreme(direction);
+            }
+
+            const position = window.scrollY + window.innerHeight / 2;
+
+            // Убираем комментарии ниже или выше направления поиска
+            const filteredComments = [...comments].filter((el) => {
+                const elBCR = el.getBoundingClientRect();
+                const eltop = elBCR.top - bodyTop;
+                return (direction === "Down") ?
+                    eltop - elBCR.height / 2 > position
+                    : eltop + elBCR.height / 2 < position;
+            });
+            if (filteredComments.length < 1) {
+                return this.scrollExtreme(direction);
+            }
+
+            // Находим ближайший к середине экрана комментарий
+            const nearest = [...filteredComments].reduce((a, b) => {
+                const atop = a.getBoundingClientRect().top - bodyTop;
+                const btop = b.getBoundingClientRect().top - bodyTop;
+                return Math.abs(btop - position) < Math.abs(atop - position) ? b : a;
+            });
+
+            const highlightComment = () => {
+                nearest.classList.add("comment-scroll-selected");
+                window.setTimeout(() => { nearest.classList.remove("comment-scroll-selected"); }, 500);
+            };
+
+            this.scrollTo(nearest.getBoundingClientRect().top - bodyTop - window.innerHeight / 2, highlightComment);
+        },
+        onArrowClickHandler() {
+            if (this.arrowDirection == "Up") {
+                this.scrollExtreme(this.arrowDirection);
+            } else {
+                this.scrollToComment(this.arrowDirection);
+            }
+        },
+        initOnPageScroll() {
+            this.onPageScrollHandler = throttle(() => {
+                const scrollPosition = Math.max(
+                    window.pageYOffset,
+                    document.documentElement.scrollTop,
+                    document.body.scrollTop
+                );
+                const bottomOfWindow = scrollPosition + window.innerHeight === document.documentElement.offsetHeight;
+                const topOfWindow = scrollPosition === 0;
+
+                if (bottomOfWindow) {
+                    this.arrowDirection = "Up";
+                }
+
+                if (topOfWindow) {
+                    this.arrowDirection = "Down";
+                }
+            }, this.scrollThrottleDelay);
+
+            window.addEventListener("scroll", this.onPageScrollHandler);
+        },
+        initOnKeyUp() {
+             this.keyUpHandler = (e) => {
+                // ctrl-up/down для всех, а в macos - ⇧⌃↑/↓
+                if (!e.ctrlKey || ["ArrowDown", "ArrowUp", "Down", "Up"].indexOf(e.key) < 0) {
+                    return;
+                }
+
+                e.preventDefault();
+                const direction = e.key.replace(/^Arrow/, "");
+
+                this.arrowDirection = direction;
+
+                this.scrollToComment(direction);
+            };
+
+            document.addEventListener("keyup", this.keyUpHandler);
+        },
+        init() {
+            this.initOnKeyUp();
+            this.initOnPageScroll();
+        }
+    },
+    mounted() {
+        this.init();
+    },
+    beforeDestroy() {
+        document.removeEventListener("keyup", this.keyUpHandler);
+        window.removeEventListener("scroll", this.onPageScrollHandler);
+    },
+};
+</script>

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -29,7 +29,9 @@ export default {
             const onScroll = () => {
                 if (window.pageYOffset.toFixed() === fixedOffset) {
                     window.removeEventListener('scroll', onScroll);
-                    callback();
+                    if (callback) {
+                        callback();
+                    }
                 }
             };
 
@@ -55,6 +57,12 @@ export default {
         scrollToComment(direction) {
             let comments = document.querySelectorAll(".comment-is-new");
             const bodyTop = this.getBodyTop();
+
+            if (comments.length < 1) {
+                // take only the first comment
+                const fistComment = document.querySelector(".comment");
+                comments = fistComment ? [fistComment] : [];
+            }
 
             if (comments.length < 1) {
                 // Без комментариев

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -18,6 +18,7 @@ export default {
         return {
             arrowDirection: "Down",
             scrollThrottleDelay: 150,
+            commentMargin: 20,
         };
     },
     methods: {
@@ -48,7 +49,7 @@ export default {
 
             if (direction === "Down") {
                 this.arrowDirection = "Up";
-                this.scrollTo(downTarget.getBoundingClientRect().top - bodyTop - window.innerHeight / 2);
+                this.scrollTo(downTarget.getBoundingClientRect().top - bodyTop - this.commentMargin);
             } else {
                 this.arrowDirection = "Down";
                 this.scrollTo(0);
@@ -69,7 +70,7 @@ export default {
                 return this.scrollExtreme(direction);
             }
 
-            const position = window.scrollY + window.innerHeight / 2;
+            const position = window.scrollY + this.commentMargin;
 
             // Убираем комментарии ниже или выше направления поиска
             const filteredComments = [...comments].filter((el) => {
@@ -95,7 +96,7 @@ export default {
                 window.setTimeout(() => { nearest.classList.remove("comment-scroll-selected"); }, 500);
             };
 
-            this.scrollTo(nearest.getBoundingClientRect().top - bodyTop - window.innerHeight / 2, highlightComment);
+            this.scrollTo(nearest.getBoundingClientRect().top - bodyTop - this.commentMargin, highlightComment);
         },
         onArrowClickHandler() {
             if (this.arrowDirection == "Up") {

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -29,11 +29,23 @@ export default {
              return parseInt(style.marginTop, 10);
          },
         scrollToElement(el, callback) {
+            const oldHash = document.location.hash;
+            const newHash = `#${el.id}`;
+            if (oldHash === newHash) {
+                // zero the hash so that there is no sticking if we are already on this element
+                document.location.hash = '';
+            }
+
+            // document.documentElement.style.scrollBehavior = "smooth";
+
             const offset = el.getBoundingClientRect().top - this.getBodyTop() - this.getElementMargin(el);
 
             const onScroll = () => {
                 if (Math.abs(offset - window.pageYOffset) < 1) {
                     window.removeEventListener('scroll', onScroll);
+
+                    // document.documentElement.style.scrollBehavior = "auto";
+
                     if (callback) {
                         callback();
                     }
@@ -64,7 +76,6 @@ export default {
             }
         },
         scrollToComment(direction) {
-            // let comments = document.querySelectorAll(".comment");
             let comments = document.querySelectorAll(
                  [
                      // Просто новые комментарии
@@ -83,8 +94,12 @@ export default {
             const bodyTop = this.getBodyTop();
 
             if (comments.length < 1) {
-                // take only the first comment
-                const commentBlock = document.getElementById("comments");
+                /**
+                 * take comments header, do not use the #comments id
+                 * because it will not work in filteredComments because of the height
+                 * also be careful to change scroll-margin-top css of .post-comments-title class (same reason)
+                 */
+                const commentBlock = document.getElementById("post-comments-title");
                 const commentBlockArray = commentBlock ? [commentBlock] : [];
 
                 // Новых нет, перебираем прочтённые комментарии
@@ -106,6 +121,7 @@ export default {
                     eltop - elBCR.height / 2 > position
                     : eltop + elBCR.height / 2 < position;
             });
+
             if (filteredComments.length < 1) {
                 return this.scrollExtreme(direction);
             }
@@ -117,10 +133,21 @@ export default {
                 return Math.abs(btop - position) < Math.abs(atop - position) ? b : a;
             });
 
+            /**
+             * remove selected class from previous selected comment
+             * do not delete immediately comment-scroll-selected class for override the target comment style
+             */
+            const alreadySelected = document.querySelector(".comment-scroll-selected");
+            if (alreadySelected) {
+                alreadySelected.classList.remove("comment-scroll-selected");
+            }
+            nearest.classList.add("comment-scroll-selected");
+
             const highlightComment = () => {
-                nearest.classList.add("comment-scroll-selected");
+                nearest.classList.add("comment-scroll-animation");
+
                 window.setTimeout(() => {
-                     nearest.classList.remove("comment-scroll-selected");
+                     nearest.classList.remove("comment-scroll-animation");
                 }, 500);
             };
 

--- a/frontend/static/js/components/InputLengthCounter.vue
+++ b/frontend/static/js/components/InputLengthCounter.vue
@@ -12,6 +12,8 @@
 </template>
 
 <script>
+import { throttle } from "../common/utils.js";
+
 export default {
     name: "InputLengthCounter",
     props: {
@@ -59,24 +61,4 @@ export default {
     },
 };
 
-function throttle(fn, wait) {
-    let inThrottle, lastFn, lastTime;
-    return function () {
-        const context = this,
-            args = arguments;
-        if (!inThrottle) {
-            fn.apply(context, args);
-            lastTime = Date.now();
-            inThrottle = true;
-        } else {
-            clearTimeout(lastFn);
-            lastFn = setTimeout(function () {
-                if (Date.now() - lastTime >= wait) {
-                    fn.apply(context, args);
-                    lastTime = Date.now();
-                }
-            }, Math.max(wait - (Date.now() - lastTime), 0));
-        }
-    };
-}
 </script>

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -19,6 +19,7 @@ Vue.component("sidebar-toggler", () => import("./components/SidebarToggler.vue")
 Vue.component("stripe-checkout-button", () => import("./components/StripeCheckoutButton.vue"));
 Vue.component("input-length-counter", () => import("./components/InputLengthCounter.vue"));
 Vue.component("friend-button", () => import("./components/FriendButton.vue"));
+Vue.component("comment-scroll-arrow", () => import("./components/CommentScrollArrow.vue"));
 
 // Since our pages have user-generated content, any fool can insert "{{" on the page and break it.
 // We have no other choice but to completely turn off template matching and leave it on only for components.


### PR DESCRIPTION
**Issue:** https://github.com/vas3k/vas3k.club/issues/491

**ПР использует механику уже существующего скроллинга комментариев кнопками ctrl-up/down, которую реализовал @simnv :** https://github.com/vas3k/vas3k.club/pull/663

**Что я добавил/изменил:**
- Добавил кнопку со стрелкой на страницах, где есть комментарии (логика реализации: https://github.com/vas3k/vas3k.club/issues/491#issuecomment-932042851)
- Перенёс логику скролла  кнопками ctrl-up/down (initializeCommentScroll) в компонент (практически as is, без изменений)
- Поменял доскролл к низу страницы на доскролл к полю комментирования
- Починил анимацию подсвечивания коммента, к которому подскролл (оставил как было blink анимацию, пишите если есть предложения как улучшить)
- Вынес функцию throttle в utils, т.к. она стала переиспользуемой

**Видео:**

https://user-images.githubusercontent.com/5123981/135762492-1b41d3f0-bf39-4a22-8a40-b9fad7c07031.mov



