### PR TITLE
Fix achievements centering on mobile

### DIFF
--- a/frontend/static/css/components/stats.css
+++ b/frontend/static/css/components/stats.css
@@ -156,6 +156,14 @@
             flex-wrap: wrap;
             flex-direction: column;
         }
+        .stats-achievements-badge {
+            display: flex;
+            justify-content: center;
+            width: 100%;
+        }
+        .stats-achievements-users {
+            justify-content: center;
+        }
     }
 
 .stats-badges-latest {


### PR DESCRIPTION
Небольшой фикс: исправление центрирования ачивок на мобильных
К #694 

<details>
<summary>Изменение</summary>

| ![Before](https://user-images.githubusercontent.com/43755002/144449454-43ec50b1-cc0f-4d9d-977e-70906efc5777.png) | ![After](https://user-images.githubusercontent.com/43755002/144449980-e0f97c02-61de-46b4-b945-3fb69a188045.png) |
|:---:|:---:|
| До | После |

</details>