### PR TITLE
Пофиксил запуск проекта для MacOS на M1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -yq \
+      build-essential \
       python3 \
+      python3-dev \
       python3-pip \
       libpq-dev \
       gdal-bin \


### PR DESCRIPTION
Фикс: https://github.com/vas3k/vas3k.club/issues/757

Добавил две зависимости при сборке докер образа: `build-essential` и `python3-dev`. Работает только если обе добавить.

После этого проект собрался и запустился без проблем через `docker-compose up`