### PR TITLE
fix: rounding in cool_number() formatting function

### DIFF
--- a/posts/templatetags/text_filters.py
+++ b/posts/templatetags/text_filters.py
@@ -10,11 +10,12 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from typus import ru_typus
 
+from utils.strings import removesuffix
+
 from common.regexp import YOUTUBE_RE
 from common.markdown.markdown import markdown_text
 
 register = template.Library()
-
 
 @register.filter(is_safe=True)
 def nl_to_p(text):
@@ -49,9 +50,9 @@ def cool_number(value, num_decimals=1):
     if int_value < 1000:
         return str(int_value)
     elif int_value < 1000000:
-        return formatted_number.format(int_value / 1000.0).rstrip("0.") + "K"
+        return removesuffix(formatted_number.format(int_value / 1000.0), ".0") + "K"
     else:
-        return formatted_number.format(int_value / 1000000.0).rstrip("0.") + "M"
+        return removesuffix(formatted_number.format(int_value / 1000000.0), ".0") + "M"
 
 
 @register.filter

--- a/posts/templatetags/text_filters.py
+++ b/posts/templatetags/text_filters.py
@@ -41,12 +41,12 @@ def floor(value):
 
 
 @register.filter
-def cool_number(value, num_decimals=1):
+def cool_number(value):
     """
     11500 -> 11.5K, etc
     """
     int_value = int(value)
-    formatted_number = "{{:.{}f}}".format(num_decimals)
+    formatted_number = "{:.1f}"
     if int_value < 1000:
         return str(int_value)
     elif int_value < 1000000:

--- a/utils/strings.py
+++ b/utils/strings.py
@@ -15,3 +15,10 @@ def random_string(length: int = 10):
 def random_number(length: int = 10):
     letters = string.digits
     return "".join(random.choice(letters) for i in range(length))
+
+# from the python standard library 3.9.0
+# https://docs.python.org/3/library/stdtypes.html#str.removesuffix
+def removesuffix(str, suffix):
+    if str.endswith(suffix) and suffix:
+        return str[:-len(suffix)]
+    return str


### PR DESCRIPTION
Related ticket: #798 

`cool_number()` used `rstrip` function as if it was `removesuffix` function, so it would eat all `0` and `.` signs at the end of the string, e.g.: 

In [1]: "10.0".rstrip("0.")
Out[1]: '1'

In [2]: "100.0".rstrip("0.")
Out[2]: '1'

In [3]: "100.000".rstrip("0.")
Out[3]: '1'


When we update to python 3.9 the `removesuffix` function implementation needs to be deleted and this function needs to be used instead: https://docs.python.org/3/library/stdtypes.html#str.removesuffix