### PR TITLE
Автозаполнение никнейма/почты на странице входа

### DIFF
--- a/frontend/html/auth/login.html
+++ b/frontend/html/auth/login.html
@@ -7,7 +7,8 @@
                 <div class="login-service-title">Вход по почте или нику</div>
                 <div class="login-service-form">
                     <form action="{% url "email_login" %}" method="post">
-                        <input type="text" name="email_or_login" value="{{ email|default:"" }}" placeholder="your@gmail.com" class="login-email" required>
+                        <input type="text" name="email_or_login" value="{{ email|default:"" }}" placeholder="your@gmail.com" class="login-email" required autocomplete="username email">
+                        <div style="display: none"><input type="password" value="none"></div>  <!--This element triggers browser's password manager-->
                         {% if goto %}<input type="hidden" name="goto" value="{{ goto }}">{% endif %}
                         <button type="submit" class="button login-button" style="min-width: 200px;">🤙 Войти</button>
                     </form>


### PR DESCRIPTION
Как бы описать проблему, особо не матерясь... 🤔

**ДОКОЛЕ?**

Для людей, у которых браузер чистит куки, заходить на сайт сейчас *может быть не совсем удобно*, т.к. юзернейм при логине не заполняется автоматически.

**Что я сделал**: добавил невидимое поле пароля, которое соблазняет парольный менеджер браузера сохранить логин/пароль, чтобы эту невыносимо длинную строку *никогда больше* не пришлось вводить руками.

**Спорные вещи**: для инпута пароля пришлось добавить фейковый дефолт `none`. При пустом поле пароля браузеры не считают нужным сохранять учётные данные, при вводе пробела (или вообще при вводе одного символа) Firefox предлагал сохранить пароль, но при этом делал пустым **username**, ради которого все мы здесь сегодня собрались.

Протестировано на последних Chrome/Firefox - будет неплохо, если какой-нибудь богатей посмотрит, как это ведёт себя на Safari.