### PR TITLE
Whois command

### DIFF
--- a/bot/handlers/whois.py
+++ b/bot/handlers/whois.py
@@ -28,7 +28,7 @@ def command_whois(update: Update, context: CallbackContext) -> None:
 
     if from_user.is_bot:
         update.message.reply_text(
-            "Это бот, глупышка",
+            "Это бот, человече",
             quote=True
         )
         return None
@@ -37,7 +37,7 @@ def command_whois(update: Update, context: CallbackContext) -> None:
     user = User.objects.filter(telegram_id=telegram_id).first()
     if not user:
         update.message.reply_text(
-            f"🤨 Пользователь не найден в Клубе. Гоните его, надсмехайтесь над ним!",
+            f"🤨 Пользователь не найден в Клубе.",
             quote=True
         )
         return None


### PR DESCRIPTION
Иногда в чат попадают пользователи, которые не привязали бота или чье интро еще на модерации. /whois такого пользователя выводит "Гоните его, надсмехайтесь над ним!", что является, конечно, мемом, но достаточно нераспостраненным, чтобы выглядеть насмешкой и неприятным призывом.

Никому не станет хуже, если заменить текст бота для этого варианта просто нейтральным информационным сообщением.

Вариант сценария с текстом "глупышка" исправлен из тех же сообжений, но оставлен изначальный посыл ироничного обращения бота к пользователю.

Все на ретро!