### PR TITLE
Add more User fields to admin panel #872

### DIFF
--- a/frontend/html/users/admin.html
+++ b/frontend/html/users/admin.html
@@ -31,6 +31,68 @@
                     {% if info_form.email.errors %}<span class="form-row-errors">{{ info_form.email.errors }}</span>{% endif %}
                 </div>
 
+                <div class="form-row form-row-right">
+                    {{ info_form.company.label_tag }}
+                    {{ info_form.company }}
+                    {% if info_form.company.errors %}<span class="form-row-errors">{{ info_form.company.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row form-row-right">
+                    {{ info_form.position.label_tag }}
+                    {{ info_form.position }}
+                    {% if info_form.position.errors %}<span class="form-row-errors">{{ info_form.position.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row form-row-right">
+                    {{ info_form.contact.label_tag }}
+                    {{ info_form.contact }}
+                    {% if info_form.contact.errors %}<span class="form-row-errors">{{ info_form.contact.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.membership_platform_type.label_tag }}
+                    {{ info_form.membership_platform_type }}
+                    {% if info_form.membership_platform_type.errors %}<span class="form-row-errors">{{ info_form.membership_platform_type.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.email_digest_type.label_tag }}
+                    {{ info_form.email_digest_type }}
+                    {% if info_form.email_digest_type.errors %}<span class="form-row-errors">{{ info_form.email_digest_type.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.telegram_id.label_tag }}
+                    {{ info_form.telegram_id }}
+                    {% if info_form.telegram_id.errors %}<span class="form-row-errors">{{ info_form.telegram_id.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.stripe_id.label_tag }}
+                    {{ info_form.stripe_id }}
+                    {% if info_form.stripe_id.errors %}<span class="form-row-errors">{{ info_form.stripe_id.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.is_email_verified.label_tag }}
+                    {{ info_form.is_email_verified }}
+                    {% if info_form.is_email_verified.errors %}<span class="form-row-errors">{{ info_form.is_email_verified.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.is_banned_until.label_tag }}
+                    {{ info_form.is_banned_until }}
+                    {{ info_form.is_banned_until.help_text }}
+                    {% if info_form.is_banned_until.errors %}<span class="form-row-errors">{{ info_form.is_banned_until.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ info_form.roles.label_tag }}
+                    {{ info_form.roles }}
+                    {{ info_form.roles.help_text }}
+                    {% if info_form.roles.errors %}<span class="form-row-errors">{{ info_form.roles.errors }}</span>{% endif %}
+                </div>
+
                 <button type="submit" class="button">Сохранить</button>
             </form>
         </div>

--- a/frontend/html/users/admin.html
+++ b/frontend/html/users/admin.html
@@ -86,11 +86,26 @@
                     {% if info_form.is_banned_until.errors %}<span class="form-row-errors">{{ info_form.is_banned_until.errors }}</span>{% endif %}
                 </div>
 
+                <button type="submit" class="button">Сохранить</button>
+            </form>
+        </div>
+
+        <div class="profile-header">Роли</div>
+        <div class="block">
+            <div class="form-row">Роли пользователя: {{ user.get_roles_display }}</div>
+            <form action="." method="post" enctype="multipart/form-data">
+                {% csrf_token %}
+
                 <div class="form-row">
-                    {{ info_form.roles.label_tag }}
-                    {{ info_form.roles }}
-                    {{ info_form.roles.help_text }}
-                    {% if info_form.roles.errors %}<span class="form-row-errors">{{ info_form.roles.errors }}</span>{% endif %}
+                    {{ form.role_action.label_tag }}
+                    {{ form.role_action }}
+                    {% if form.role_action.errors %}<span class="form-row-errors">{{ form.role_action.errors }}</span>{% endif %}
+                </div>
+
+                <div class="form-row">
+                    {{ form.role.label_tag }}
+                    {{ form.role }}
+                    {% if form.role.errors %}<span class="form-row-errors">{{ form.role.errors }}</span>{% endif %}
                 </div>
 
                 <button type="submit" class="button">Сохранить</button>

--- a/misc/views.py
+++ b/misc/views.py
@@ -39,7 +39,7 @@ def stats(request):
     moderators = User.objects\
         .filter(Q(roles__contains=[User.ROLE_MODERATOR]) | Q(roles__contains=[User.ROLE_GOD]))
 
-    parliament = User.objects.filter(roles__contains=[User.ROLE_CURATOR])
+    parliament = User.objects.filter(achievements__achievement_id="parliament_member")
 
     top_users = User.objects\
         .filter(

--- a/misc/views.py
+++ b/misc/views.py
@@ -39,7 +39,7 @@ def stats(request):
     moderators = User.objects\
         .filter(Q(roles__contains=[User.ROLE_MODERATOR]) | Q(roles__contains=[User.ROLE_GOD]))
 
-    parliament = User.objects.filter(achievements__achievement_id="parliament_member")
+    parliament = User.objects.filter(roles__contains=[User.ROLE_CURATOR])
 
     top_users = User.objects\
         .filter(

--- a/users/admin.py
+++ b/users/admin.py
@@ -59,11 +59,6 @@ def do_user_admin_actions(request, user, data):
                 send_banned_email(user, days=data["ban_days"], reason=data["ban_reason"])
                 notify_admin_user_on_ban(user, days=data["ban_days"], reason=data["ban_reason"])
 
-    # Unban
-    if data["is_unbanned"]:
-        user.is_banned_until = None
-        user.save()
-
     # Unmoderate
     if data["is_rejected"]:
         user.moderation_status = User.MODERATION_STATUS_REJECTED

--- a/users/admin.py
+++ b/users/admin.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 
 from django.conf import settings
 from django.shortcuts import redirect
-from django_q.tasks import async_task
 
 from auth.models import Session
 from club.exceptions import AccessDenied
@@ -15,11 +14,22 @@ from notifications.telegram.users import notify_user_ping, notify_admin_user_pin
 from payments.helpers import cancel_all_stripe_subscriptions
 from users.models.achievements import UserAchievement, Achievement
 from users.models.user import User
+from users.utils import is_role_manageable_by_user
 
 
 def do_user_admin_actions(request, user, data):
     if not request.me.is_moderator:
         raise AccessDenied()
+
+    # Roles
+    if data["role"] and is_role_manageable_by_user(data["role"], request.me):
+        role = data["role"]
+        if data["role_action"] == "add" and role not in user.roles:
+            user.roles.append(role)
+            user.save()
+        if data["role_action"] == "delete" and role in user.roles:
+            user.roles.remove(role)
+            user.save()
 
     # Hats
     if data["remove_hat"]:

--- a/users/forms/admin.py
+++ b/users/forms/admin.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.postgres.forms import SimpleArrayField
 from django.forms import ModelForm
 
 from common.data.achievements import ACHIEVEMENTS
@@ -57,11 +58,6 @@ class UserAdminForm(forms.Form):
         widget=forms.Textarea(attrs={"maxlength": 5000}),
     )
 
-    is_unbanned = forms.BooleanField(
-        label="Разбанить",
-        required=False
-    )
-
     is_rejected = forms.BooleanField(
         label="Размодерирвать",
         required=False
@@ -100,6 +96,61 @@ class UserInfoAdminForm(ModelForm):
         label="E-mail",
         required=True
     )
+    company = forms.CharField(
+        label="Компания",
+        required=False,
+        max_length=128,
+    )
+    position = forms.CharField(
+        label="Должность",
+        required=False,
+        max_length=128,
+    )
+    contact = forms.CharField(
+        label="Контакт для связи",
+        required=False,
+        max_length=256,
+    )
+    membership_platform_type = forms.ChoiceField(
+        label="Тип платформы подписки",
+        choices=User.MEMBERSHIP_PLATFORMS,
+        required=True,
+    )
+    email_digest_type = forms.ChoiceField(
+        label="Тип email-дайджеста",
+        required=True,
+        choices=User.EMAIL_DIGEST_TYPES,
+    )
+    telegram_id = forms.CharField(
+        label="Телеграм",
+        required=False,
+        max_length=128
+    )
+    stripe_id = forms.CharField(
+        label="Страйп",
+        required=False,
+        max_length=128
+    )
+    is_email_verified = forms.BooleanField(
+        label="Статус активации email",
+        required=False
+    )
+    is_banned_until = forms.DateTimeField(
+        label="Бан истечет",
+        help_text="Например: 23.01.2022 01:09:31",
+        required=False,
+    )
+    roles = SimpleArrayField(
+        label="Роли",
+        help_text="Можно добавить несколько через запятую. Например: curator,moderator",
+        required=False,
+        base_field=forms.ChoiceField(
+            choices=[
+                (User.ROLE_CURATOR, User.ROLE_CURATOR),
+                (User.ROLE_MODERATOR, User.ROLE_MODERATOR),
+            ],
+        ),
+    )
 
     class Meta:
         model = User
@@ -107,4 +158,14 @@ class UserInfoAdminForm(ModelForm):
             "slug",
             "full_name",
             "email",
+            "company",
+            "position",
+            "contact",
+            "membership_platform_type",
+            "email_digest_type",
+            "telegram_id",
+            "stripe_id",
+            "is_email_verified",
+            "is_banned_until",
+            "roles",
         ]

--- a/users/forms/admin.py
+++ b/users/forms/admin.py
@@ -9,6 +9,16 @@ from users.models.user import User
 
 
 class UserAdminForm(forms.Form):
+    role_action = forms.ChoiceField(
+        label="Выбрать действие",
+        choices=[(None, "---"), ("add", "Добавить роль"), ("delete", "Удалить роль")],
+        required=False,
+    )
+    role = forms.ChoiceField(
+        label="Выбрать роль",
+        choices=[(None, "---")] + User.ROLES,
+        required=False,
+    )
     add_hat = forms.BooleanField(label="Выдать новую шапку", required=False)
     new_hat = forms.ChoiceField(
         label="Выбрать из популярных",
@@ -140,17 +150,6 @@ class UserInfoAdminForm(ModelForm):
         help_text="Например: 23.01.2022 01:09:31",
         required=False,
     )
-    roles = SimpleArrayField(
-        label="Роли",
-        help_text="Можно добавить несколько через запятую. Например: curator,moderator",
-        required=False,
-        base_field=forms.ChoiceField(
-            choices=[
-                (User.ROLE_CURATOR, User.ROLE_CURATOR),
-                (User.ROLE_MODERATOR, User.ROLE_MODERATOR),
-            ],
-        ),
-    )
 
     class Meta:
         model = User
@@ -167,5 +166,4 @@ class UserInfoAdminForm(ModelForm):
             "stripe_id",
             "is_email_verified",
             "is_banned_until",
-            "roles",
         ]

--- a/users/models/user.py
+++ b/users/models/user.py
@@ -189,6 +189,15 @@ class User(models.Model, ModelDiffMixin):
     def secret_auth_code(self):
         return f"{self.email}|-{self.secret_hash}"
 
+    @property
+    def get_roles_display(self):
+        d = dict(User.ROLES)
+
+        roles = []
+        for role in self.roles:
+            roles.append(d[role])
+        return ", ".join(roles)
+
     @classmethod
     def registered_members(cls):
         return cls.objects.filter(

--- a/users/utils.py
+++ b/users/utils.py
@@ -8,3 +8,11 @@ def calculate_similarity(my, theirs, tags):
         same = my_names & their_names
         similarity[group] = len(same) * 100 / len(both) if both else 0
     return similarity
+
+
+def is_role_manageable_by_user(role, user):
+    if role in (user.ROLE_GOD, user.ROLE_MODERATOR):
+        return user.is_god
+    if role == user.ROLE_CURATOR:
+        return user.is_moderator
+    return False


### PR DESCRIPTION
Как и обсуждалось в [issue](https://github.com/vas3k/vas3k.club/issues/872) добавил больше полей в админскую панель.

Выглядит это так:

<img width="407" alt="Screenshot 2022-01-18 at 8 13 18 PM" src="https://user-images.githubusercontent.com/36140450/150003255-46717faf-af9d-464a-9245-09a599f56c48.png">

Так же сделал небольшие дополнительные изменения по правилу бойскаута (комментарии оставлены ниже).