### PR TITLE
Возможность скопировать комментарий в виде Markdown-кода

### DIFF
--- a/comments/models.py
+++ b/comments/models.py
@@ -101,6 +101,10 @@ class Comment(models.Model):
         return None
 
     @property
+    def editable_hours(self):
+        return int(settings.COMMENT_EDITABLE_TIMEDELTA.total_seconds() // 3600)
+
+    @property
     def is_editable(self):
         return self.created_at >= datetime.utcnow() - settings.COMMENT_EDITABLE_TIMEDELTA
 

--- a/comments/views.py
+++ b/comments/views.py
@@ -107,19 +107,18 @@ def edit_comment(request, comment_id):
                 message="Сначала тот, кто его удалил, должен его восстановить"
             )
 
-        if not comment.is_editable:
-            hours = int(settings.COMMENT_EDITABLE_TIMEDELTA.total_seconds() // 3600)
-            raise AccessDenied(
-                title="Время вышло",
-                message=f"Комментарий можно редактировать только в течение {hours} часов после создания"
-            )
-
         if not comment.post.is_visible or not comment.post.is_commentable:
             raise AccessDenied(title="Комментарии к этому посту закрыты")
 
     post = comment.post
 
     if request.method == "POST":
+        if not comment.is_editable:
+            raise AccessDenied(
+                title="Время вышло",
+                message=f"Комментарий можно редактировать только в течение {comment.editable_hours} часов после создания"
+            )
+
         form = CommentForm(request.POST, instance=comment)
         if form.is_valid():
             comment = form.save(commit=False)

--- a/frontend/html/comments/edit.html
+++ b/frontend/html/comments/edit.html
@@ -3,6 +3,12 @@
 
 {% block content %}
     <div class="content comment">
+        {% if not comment.is_editable %}
+            <div class="error">
+                <h2>Время вышло</h2>
+                <p>Комментарий можно редактировать только в течение {{ comment.editable_hours }} часов после создания.</p>
+            </div>
+        {% endif %}
         <form action="{% url "edit_comment" comment.id %}" method="post" class="form comment-form-form">
             <div class="comment-form">
                 <div class="comment-form-avatar">
@@ -14,9 +20,7 @@
                     </comment-markdown-editor>
                     {% if form.text.errors %}<span class="form-errors">{{ form.full_name.errors }}</span>{% endif %}
                 </div>
-                <div class="comment-form-button">
-                    <button type="submit" class="button">Сохранить</button>
-                </div>
+                {% if comment.is_editable %}<div class="comment-form-button"><button type="submit" class="button">Сохранить</button></div>{% endif %}
             </div>
         </form>
     </div>


### PR DESCRIPTION
Реализация к обсуждению https://github.com/vas3k/vas3k.club/discussions/874.

### Есть старый комментарий:
<img width="852" alt="Screenshot 2022-01-27 at 14 38 02" src="https://user-images.githubusercontent.com/6163085/151402736-abe85dd7-4f75-4334-86d8-8e1129749e0c.png">

### Так выглядит попытка его отредактировать:
<img width="740" alt="Screenshot 2022-01-27 at 14 38 17" src="https://user-images.githubusercontent.com/6163085/151402742-53c86562-4693-4e7e-a4c4-3971cb2d36b3.png">

### Предлагается сделать так, чтоб оставалась возможность скопировать свой старый коммент:
<img width="1098" alt="Screenshot 2022-01-27 at 16 07 02" src="https://user-images.githubusercontent.com/6163085/151402760-0cb70293-f0b4-4d7d-8c44-81c9bcc60d59.png">

Что произошло:
- теперь нет `AccessDenied` при простом открытии окна комментария, убрал кнопку Сохранить
- хацкеры при попытке отправить POST запрос всё ещё получат `AccessDenied`
