### PR TITLE
Clickable telegram code on macOS

### DIFF
--- a/notifications/telegram/users.py
+++ b/notifications/telegram/users.py
@@ -91,7 +91,7 @@ def notify_user_auth(user, code):
     if user.telegram_id:
         send_telegram_message(
             chat=Chat(id=user.telegram_id),
-            text=f"<pre>{code.code}</pre> — ваш одноразовый код для входа в Клуб",
+            text=f"<code>{code.code}</code> — ваш одноразовый код для входа в Клуб",
         )
 
 


### PR DESCRIPTION
Сделано по https://github.com/vas3k/vas3k.club/discussions/850. 

Одноразовый код для входа в клуб можно нажать, чтобы скопировать в буфер обмена, но это не работало в телеграм клиенте на macOS. Теперь должно работать везде.

<img width="463" alt="image" src="https://user-images.githubusercontent.com/30183178/154702062-2e64e29e-cba3-4b5b-b959-e00aa0abc3e3.png">
