### PR TITLE
Add full markdown editor to users/intro page

### DIFF
--- a/comments/forms.py
+++ b/comments/forms.py
@@ -13,7 +13,6 @@ class CommentForm(forms.ModelForm):
             attrs={
                 "maxlength": 20000,
                 "placeholder": "Напишите комментарий...",
-                "class": "markdown-editor-invisible",
             }
         ),
     )
@@ -32,7 +31,6 @@ class ReplyForm(forms.ModelForm):
             attrs={
                 "maxlength": 20000,
                 "placeholder": "Напишите ответ...",
-                "class": "markdown-editor-invisible",
             }
         ),
     )
@@ -79,7 +77,6 @@ class BattleCommentForm(forms.ModelForm):
             attrs={
                 "maxlength": 20000,
                 "placeholder": "Развернутый ответ...",
-                "class": "markdown-editor-invisible",
             }
         ),
     )

--- a/frontend/html/users/intro.html
+++ b/frontend/html/users/intro.html
@@ -160,6 +160,10 @@
             <div class="form-row form-row-intro">
                 {{ form.intro }}
                 {% if form.intro.errors %}<span class="form-row-errors">{{ form.intro.errors }}</span>{% endif %}
+                <span class="form-row-help form-row-help-wide">
+                    Можно использовать <a href="https://www.markdownguide.org/basic-syntax/" target="_blank">Markdown</a>.
+                    Для загрузки картинок просто перетащите их в редактор.
+                </span>
                 <input-length-counter
                     element="#{{ form.intro.id_for_label }}"
                     class="intro-form-counter"

--- a/frontend/static/css/components.css
+++ b/frontend/static/css/components.css
@@ -763,6 +763,13 @@
             transform: scale(1);
         }
 
+        .intro-form .form-row-intro .CodeMirror,
+        .intro-form .form-row-intro .CodeMirror-focused,
+        .intro-form .form-row-intro .CodeMirror-scroll {
+            min-height: 700px !important;
+            transform: scale(1);
+        }
+
         .form-row #id_company {
             max-width: 400px;
             font-weight: 500;

--- a/users/forms/intro.py
+++ b/users/forms/intro.py
@@ -73,6 +73,7 @@ class UserIntroForm(ModelForm):
             attrs={
                 "maxlength": 10000,
                 "minlength": 600,
+                "class": "markdown-editor-full",
                 "placeholder": "Расскажите Клубу о себе...",
             }
         ),


### PR DESCRIPTION
Partially fixes #619.

I'm not exactly sure what the CSS is doing, but it's copied from what's used by the editor on the profile page and without it the page looks like this:

![изображение](https://user-images.githubusercontent.com/1297325/155239339-17ca9d78-510f-4dd3-84ba-965769f7534f.png)

This PR looks like this:

![изображение](https://user-images.githubusercontent.com/1297325/155239388-90b82f2c-5d6c-4d01-974e-f906eec759ab.png)

Some other places which may or may not need markdown editor:

* I was unable to test locally:
  * `GodmodeNetworkSettingsEditForm.network_page`
  * `PostAnnounceForm.text`
  * `users/forms/admin.py`:
    * `ban_reason`
    * `ping`
* Actually need `markdown-editor-invisible` which never existed in the first place:
  * `bio` at `users/forms/intro.py` and `users/forms/profile.py`