### PR TITLE
Fix radio items on small resolutions

### DIFF
--- a/frontend/static/css/base.css
+++ b/frontend/static/css/base.css
@@ -723,6 +723,15 @@ img.emoji {
     font-size: 17px;
 }
 
+    @media only screen and (max-width : 620px) {
+        .big-radio {
+            flex-direction: column;
+        }
+        .big-radio .big-radio-item {
+            min-height: fit-content;
+        }
+    }
+
     .big-radio-item {
         display: block;
         cursor: pointer;


### PR DESCRIPTION
Поправил radio элементы на маленьких разрешениях, [багрепорт](https://github.com/vas3k/vas3k.club/issues/936).

На скриншотах слева до, справа после.

![1](https://user-images.githubusercontent.com/17778661/169411754-d1cc032a-6b81-4d5a-a623-49da4ca13ede.png)
![2](https://user-images.githubusercontent.com/17778661/169411761-c1a7059b-d169-4c90-a71b-911451dcda1f.png)
![3](https://user-images.githubusercontent.com/17778661/169411767-5b0d8328-3b18-44d2-87fe-1fc94f6af1f8.png)