### PR TITLE
[Improvement] Case-insensitive login by slug (nickname)

### DIFF
--- a/auth/views/email.py
+++ b/auth/views/email.py
@@ -44,7 +44,7 @@ def email_login(request):
         return set_session_cookie(response, user, session)
     else:
         # email/nickname login
-        user = User.objects.filter(Q(email=email_or_login.lower()) | Q(slug=email_or_login)).first()
+        user = User.objects.filter(Q(email=email_or_login.lower()) | Q(slug__iexact=email_or_login)).first()
         if not user:
             return render(request, "error.html", {
                 "title": "Такого юзера нет 🤔",


### PR DESCRIPTION
Часто при логине по нику с телефона автоматически вводится ник с заглавной буквы. 
Далее джанга ищет по точному совпадению в БД и не находит пользователя. Приходится вспоминать, в каком формате писал ник при регистрации, а это неудобненько)
Предлагаю сделать изи фикс - регистронезависимый поиск по slug.