### PR TITLE
Upgrade CodeQL Action to v2

### DIFF
--- a/.github/workflows/codeql-vulnerability-analysis.yml
+++ b/.github/workflows/codeql-vulnerability-analysis.yml
@@ -39,7 +39,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -50,7 +50,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v2
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -64,4 +64,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
> On March 30, 2022, we released CodeQL Action v2, which runs on the
> Node.js 16 runtime. The CodeQL Action v1 will be deprecated at the same
> time as GHES 3.3, which is currently scheduled for December 2022.

https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/