### PR TITLE
Add image upload button for mobile devices

### DIFF
--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -668,3 +668,15 @@
     .mention-autocomplete-hint__option--suggested span {
         color: #fff;
     }
+
+    .comment-mobile-tools {
+      position: absolute;
+      left: 5px;
+      bottom: 100%;
+      margin-bottom: 8px;
+    }
+    @media only screen and (min-width : 600px) {
+      .comment-mobile-tools {
+        visibility: hidden;
+      }
+    }

--- a/frontend/static/js/codemirror-4.inline-attachment.js
+++ b/frontend/static/js/codemirror-4.inline-attachment.js
@@ -89,5 +89,16 @@
         });
     };
 
+    codeMirrorEditor4.attachMobile = function (codeMirror, options, mobileToolsEl) {
+      options = options || {};
+
+      var editor = new codeMirrorEditor(codeMirror),
+          inlineattach = new inlineAttachment(options, editor);
+
+      mobileToolsEl
+          .querySelector("input[type='file']")
+          .addEventListener("change", (e) => inlineattach.onFileInputChange(e));
+  };
+
     inlineAttachment.editors.codemirror4 = codeMirrorEditor4;
 })();

--- a/frontend/static/js/components/CommentMarkdownEditor.vue
+++ b/frontend/static/js/components/CommentMarkdownEditor.vue
@@ -1,5 +1,11 @@
 <template>
     <div class="comment-markdown-editor">
+        <div class="comment-mobile-tools">
+            <label :style="{ padding: '8px 10px', cursor: 'pointer' }">
+                <i class="fas fa-image"></i>
+                <input type="file" multiple accept="image/*" :style="{ display: 'none' }" />
+            </label>
+        </div>
         <slot></slot>
         <div
             class="mention-autocomplete-hint"
@@ -27,14 +33,20 @@ import { createMarkdownEditor, handleFormSubmissionShortcuts, imageUploadOptions
 
 export default {
     mounted() {
-        if (isMobile()) {
-            return;
-        }
-
-        const $markdownElementDiv = this.$el.children[0];
+        const $markdownElementDiv = this.$el.children[1];
         this.editor = createMarkdownEditor($markdownElementDiv, {
             toolbar: false,
         });
+
+        if (isMobile()) {
+            const $mobileToolsEl = this.$el.children[0];
+            inlineAttachment.editors.codemirror4.attachMobile(
+                this.editor.codemirror,
+                imageUploadOptions,
+                $mobileToolsEl
+            );
+            return;
+        }
 
         this.editor.element.form.addEventListener("keydown", handleFormSubmissionShortcuts);
         inlineAttachment.editors.codemirror4.attach(this.editor.codemirror, imageUploadOptions);

--- a/frontend/static/js/inline-attachment.js
+++ b/frontend/static/js/inline-attachment.js
@@ -393,5 +393,25 @@
         return result;
     };
 
-    window.inlineAttachment = inlineAttachment;
+    /**
+     * Called when input[type="file"] onChange event occurs
+     * @param  {Event} e
+     * @return {Boolean} if the event was handled
+     */
+     inlineAttachment.prototype.onFileInputChange = function (e) {
+      var result = false;
+      for (var i = 0; i < e.target.files.length; i++) {
+          var file = e.target.files[i];
+          console.log(this);
+          if (this.isFileAllowed(file)) {
+              result = true;
+              this.onFileInserted(file);
+              this.uploadFile(file);
+          }
+      }
+
+      return result;
+  };
+
+  window.inlineAttachment = inlineAttachment;
 })(document, window);


### PR DESCRIPTION
_Только для мобильной версии._

Добавил кнопку загрузки картинки (#715)

https://user-images.githubusercontent.com/2889382/185500113-32699a25-60e2-4979-8e3a-61ea2a2429eb.mov

NB:
1) в CommentMarkdownEditor.vue `mounted()` на мобиле возвращался сразу. Теперь же он таки-создает codeMirrorEditor, хоть и с ограничениями (т.е. на мобилке теперь еще и заработала подсветка markdown, как на десктопе). Возможно, была причина, по которой на мобилах отрубили markdown.

2) я впервые смотрю на vue, так что чекните плиз компонент на адекватность.

3) inline-attachment (и не только) напрашивается на рефактор, который я решил в данном пиаре не делать, так как фича и без того весомая.