### PR TITLE
Автоматический /whois на все форварды в личке бота

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -49,7 +49,7 @@ def private_message(update: Update, context: CallbackContext) -> None:
         )
     else:
         update.effective_chat.send_message(
-            "Йо! Полный список моих команд покажет /help,"
+            "Йо! Полный список моих команд покажет /help, "
             "а еще мне можно отвечать на посты и уведомления, всё это будет поститься прямо в Клуб!",
             parse_mode=ParseMode.HTML
         )

--- a/bot/main.py
+++ b/bot/main.py
@@ -85,6 +85,7 @@ def main() -> None:
     # Only private chats
     dispatcher.add_handler(CommandHandler("start", auth.command_auth, Filters.private))
     dispatcher.add_handler(CommandHandler("auth", auth.command_auth, Filters.private))
+    dispatcher.add_handler(MessageHandler(Filters.forwarded & Filters.private, whois.command_whois))
     dispatcher.add_handler(MessageHandler(Filters.private, private_message))
 
     # Start the bot


### PR DESCRIPTION
Я часто тихонько пересылаю чье-то чужое сообщения из "Бара" в бота и делаю "/whois". Это происходит четыремя сообщениями:

![whois](https://user-images.githubusercontent.com/28492051/186788951-b569d184-2fd8-4a1a-8fbe-12cde12fcc1a.png)

Если этот PR будет принят, whois будет сразу срабатывать на все forwards в приватных сообщениях. То есть после форварда "Вастрика" сразу придет "Кажется, он скрыл профиль..."

А еще мозолящую глаз опечатку убрал. На скрине она тоже видна.