### PR TITLE
fix: auto-whois in command_whois

### DIFF
--- a/bot/handlers/whois.py
+++ b/bot/handlers/whois.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 from telegram import Update, ParseMode
+from telegram import Chat as TGChat
 from telegram.ext import CallbackContext
 
 from bot.decorators import is_club_member
@@ -9,22 +10,26 @@ from users.models.user import User
 
 @is_club_member
 def command_whois(update: Update, context: CallbackContext) -> None:
-    if not update.message or not update.message.reply_to_message:
+    is_private_forward = update.message.forward_date is not None and update.message.chat.type == TGChat.PRIVATE
+    if not update.message or not update.message.reply_to_message and not is_private_forward:
         update.effective_chat.send_message(
             "Эту команду нужно вызывать реплаем на сообщение человека, о котором вы хотите узнать",
             quote=True
         )
         return None
 
-    from_user = update.message.reply_to_message.from_user
-    if update.message.reply_to_message.forward_date:
-        if not update.message.reply_to_message.forward_from:
+    original_message = update.message  # look at the author of this message (works only in private chats)
+    if update.message.reply_to_message:
+        original_message = update.message.reply_to_message  # look at the author of replied message
+    from_user = original_message.from_user
+    if original_message.forward_date:
+        if not original_message.forward_from:
             update.effective_chat.send_message(
-                f"🤨 Кажется, {update.message.reply_to_message.forward_sender_name} скрыл свой профиль для пересылаемых сообщений. Попробуй дать команду в ответ на исходное сообщение",
+                f"🤨 Кажется, {original_message.forward_sender_name} скрыл свой профиль для пересылаемых сообщений. Попробуй дать команду в ответ на исходное сообщение",
                 quote=True
             )
             return None
-        from_user = update.message.reply_to_message.forward_from
+        from_user = original_message.forward_from
 
     if from_user.is_bot:
         update.message.reply_text(

--- a/bot/main.py
+++ b/bot/main.py
@@ -49,7 +49,7 @@ def private_message(update: Update, context: CallbackContext) -> None:
         )
     else:
         update.effective_chat.send_message(
-            "Йо! Полный список моих команд покажет /help,"
+            "Йо! Полный список моих команд покажет /help, "
             "а еще мне можно отвечать на посты и уведомления, всё это будет поститься прямо в Клуб!",
             parse_mode=ParseMode.HTML
         )

--- a/bot/main.py
+++ b/bot/main.py
@@ -85,6 +85,7 @@ def main() -> None:
     # Only private chats
     dispatcher.add_handler(CommandHandler("start", auth.command_auth, Filters.private))
     dispatcher.add_handler(CommandHandler("auth", auth.command_auth, Filters.private))
+    dispatcher.add_handler(MessageHandler(Filters.forwarded & Filters.private, whois.command_whois))
     dispatcher.add_handler(MessageHandler(Filters.private, private_message))
 
     # Start the bot


### PR DESCRIPTION
Так, прошу прощения за недоделанный #979, почему-то думал, что жизнь простая, shit happens. В прошлом PR форварды обрабатывались как обычный whois и падали на первой же проверке, потому что не было реплая.

В этот раз whois действительно срабатывает, как ожидается:
1. (без изменений) реплаем с командой /whois в личке и в группе на обычное сообщение
2. (без изменений) реплаем с командой /whois в личке и в группе на форвард
3. обычным форвардом в личку (ожидаемо не стриггерится на форвард в группе)

![q_002](https://user-images.githubusercontent.com/28492051/186982298-aecc9a0b-e27d-4161-82fe-13ab2023c506.png)