### PR TITLE
Speed up tests in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,18 +6,28 @@ on:
       - master
   pull_request:
 
+concurrency:
+  # For pull requests, cancel all currently-running jobs for this workflow
+  # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: actions/setup-python@v2
+
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        id: setup-python
         with:
           python-version: '3.8'
-          architecture: 'x64'
+
       - name: Install requirements
         run: |
           pip install --no-cache-dir flake8
+
       - name: run flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -27,24 +37,84 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: vas3k_club
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:6-alpine
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+        ports:
+          - 6379:6379
+
     steps:
-      - uses: actions/checkout@master
-      - name: Build image
-        run: |
-          docker-compose -f docker-compose.test.yml build
-      - name: Run postgres
-        run: |
-          docker-compose -f docker-compose.test.yml up -d postgres
-      - name: Run redis
-        run: |
-          docker-compose -f docker-compose.test.yml up -d redis
-      - name: Run frontend
-        run: |
-          docker-compose -f docker-compose.test.yml up -d webpack
-      - name: Wait postgres
-        uses: jakejarvis/wait-action@master
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        id: setup-python
         with:
-          time: '20s'
-      - name: Run tests
+          python-version: '3.8'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '14'
+
+      - name: ⚡️ Cache webpack build
+        uses: actions/cache@v3
+        id: cache-webpack
+        with:
+          path: |
+            frontend/static/dist
+            frontend/webpack-stats.json
+          key: ${{ runner.os }}-webpack-${{ hashFiles('frontend/package*.json', 'frontend/webpack*.js') }}
+
+      - name: 🏗 Webpack build
+        if: steps.cache-webpack.outputs.cache-hit != 'true'
+        working-directory: ./frontend
         run: |
-          docker-compose -f docker-compose.test.yml run --rm tests
+          node -v
+          npm -v
+          npm ci
+          npm run build
+
+      - name: ⚡️ Cache python virtualenv
+        uses: actions/cache@v3
+        id: cache-venv
+        with:
+          path: |
+            venv
+          key: ${{ runner.os }}-venv-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('Pipfile.lock') }}
+
+      - name: Install pip dependencies
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv venv
+          . venv/bin/activate
+          pip install --upgrade pip pipenv==2021.5.29
+          pipenv lock --dev --requirements > requirements.txt
+          pip install -r requirements.txt
+
+      - name: Run tests
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: vas3k_club
+          POSTGRES_HOST: localhost
+          REDIS_DB: 0
+          REDIS_HOST: localhost
+          PYTHONUNBUFFERED: 1
+          TESTS_RUN: da
+        run: |
+          . venv/bin/activate
+          make test-ci


### PR DESCRIPTION
* Get rid of `docker-compose` execution for tests. Use `postgres` and `redis` services instead
* Use python 3.8 and node 14 to replicate `docker-compose` setup
* Use cache for pip packages and webpack build.
* postgres 12 as in prod docker-compose

Fixes #996