### PR TITLE
Replace history in 'CommentScrollArrow'

### DIFF
--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -57,7 +57,7 @@ export default {
             window.addEventListener("scroll", onScroll);
             onScroll();
 
-            document.location.hash = `#${el.id}`;
+            document.location.replace(`#${el.id}`);
         },
         scrollExtreme(direction) {
             if (direction === "Down") {


### PR DESCRIPTION
Assigning the value behaves as a `location.push` and adds a new item into the `history` which makes it hard for users to jump to the previous **page** i.e. feed.

Replacing, on the other hand, allows going to the previous page with a single "go back".

See also: https://github.com/vas3k/vas3k.club/discussions/1001