### PR TITLE
Add user active membership check in replies

### DIFF
--- a/frontend/html/comments/types/reply.html
+++ b/frontend/html/comments/types/reply.html
@@ -83,7 +83,7 @@
                 <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button reply-button-hidden"><i class="fas fa-edit"></i></a>
             {% endif %}
 
-	    {% if me and comment.post.is_commentable %}
+	    {% if me and me.is_active_membership and comment.post.is_commentable %}
             <span class="comment-footer-button" v-on:click="showReplyForm('{{ reply_to.id }}', '{{ comment.author.slug }}', true)">
                 <i class="fas fa-reply"></i>&nbsp;ответить
             </span>


### PR DESCRIPTION
По аналогии как недавно было выяснено, что в реплаях не хватает проверок на `is_commentable`, добавил туда проверку на активную подписку

Было:
<img width="927" alt="Screenshot 2022-12-28 at 10 41 35 PM" src="https://user-images.githubusercontent.com/36140450/209875934-fc6c1e51-9dc9-40e6-88d1-ee3583a293cf.png">


Стало:
<img width="861" alt="Screenshot 2022-12-28 at 10 42 18 PM" src="https://user-images.githubusercontent.com/36140450/209875956-13a701a7-dcdc-40b4-9038-4c19f87ad717.png">

