### PR TITLE
Fix regex for emoji verification

### DIFF
--- a/frontend/html/posts/compose/elements/post_settings.html
+++ b/frontend/html/posts/compose/elements/post_settings.html
@@ -23,7 +23,7 @@
             id="{{ form.collectible_tag_code.html_name }}"
             search-url="/search/tags.json?prefix="
             allow-create-new
-            validation-reg-exp="^(\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]) .+$"
+            validation-reg-exp='emojiValidationRegex'
             label-prefix-input="Добавить тег: "
             label-invalid-input="Каждый тег обязан начинаться с emoji, потом идёт пробел и название."
             label-valid-input="Вы добавите этот тег первым!"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,8 @@
     "twemoji": "^13.0.2",
     "vue": "^2.6.11",
     "vue-select": "^3.18.3",
-    "vue-mapbox": "^0.4.1"
+    "vue-mapbox": "^0.4.1",
+    "emoji-regex": "^10.2.1"
   },
   "husky": {
     "hooks": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "vue": "^2.6.11",
     "vue-select": "^3.18.3",
     "vue-mapbox": "^0.4.1",
-    "emoji-regex": "^10.2.1"
+    "emoji-regex": "^8.0.0"
   },
   "husky": {
     "hooks": {

--- a/frontend/static/js/common/utils.js
+++ b/frontend/static/js/common/utils.js
@@ -1,3 +1,5 @@
+import emojiRegex from "emoji-regex";
+
 export const findParentForm = (element) => {
     let form = element.parentElement;
 
@@ -81,3 +83,5 @@ export const debounce = (func, wait, immediate) => {
         }
     };
 }
+
+export const emojiValidationRegex = `^(${emojiRegex()}) .+$`

--- a/frontend/static/js/components/MultiSelect.vue
+++ b/frontend/static/js/components/MultiSelect.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script>
-import { debounce } from "../common/utils";
+import { debounce, emojiValidationRegex } from "../common/utils";
 
 
 export default {
@@ -109,12 +109,16 @@ export default {
             selectValue: null,
             formValue: null,
             options: [],
+            emojiValidationRegex: emojiValidationRegex,
         };
     },
     computed: {
         validationRe() {
             if (!this.validationRegExp) {
                 return null;
+            }
+            if (this.validationRegExp === "emojiValidationRegex") {
+                return new RegExp(this.emojiValidationRegex);
             }
 
             return new RegExp(this.validationRegExp);


### PR DESCRIPTION
#### [Issue](https://github.com/vas3k/vas3k.club/issues/993) - Баг: Коллекционный тег "ест" не все эмодзи

Проблема была в регулярке, которая проверяет, что был введен emoji
Заменил ее на регулярку от [сюда](https://github.com/mathiasbynens/emoji-regex/blob/main/index.js)

Проверял регулярки на regex101:
Старая:
<img width="715" alt="Screenshot 2022-12-30 at 22 54 41" src="https://user-images.githubusercontent.com/23433684/210134018-2a263375-bf6a-436f-bb56-2635ca1d6a1b.png">

Новая:
<img width="859" alt="Screenshot 2022-12-30 at 23 14 02" src="https://user-images.githubusercontent.com/23433684/210134019-e8168b1e-8c91-441c-bd21-ea426c1d68f8.png">

Теперь можно добавить красное сердечко из описания проблемы:
<img width="760" alt="Screenshot 2022-12-31 at 11 21 52" src="https://user-images.githubusercontent.com/23433684/210134014-63b752e0-92ca-476a-b278-96552c2792e4.png">
