### PR TITLE
Wrong profile pluses counter for 1k+ trailing zeroes values

### DIFF
--- a/posts/templatetags/text_filters.py
+++ b/posts/templatetags/text_filters.py
@@ -49,9 +49,9 @@ def cool_number(value, num_decimals=1):
     if int_value < 1000:
         return str(int_value)
     elif int_value < 1000000:
-        return formatted_number.format(int_value / 1000.0).rstrip("0.") + "K"
+        return formatted_number.format(int_value / 1000.0).rstrip("0").rstrip(".") + "K"
     else:
-        return formatted_number.format(int_value / 1000000.0).rstrip("0.") + "M"
+        return formatted_number.format(int_value / 1000000.0).rstrip("0").rstrip(".") + "M"
 
 
 @register.filter


### PR DESCRIPTION
Новая попытка пофиксить критикал баг #798. Даже сейчас у [вастрика](https://vas3k.club/user/vas3k/) отображается только 3к плюсиков, когда должно быть, скорее всего, 33к

<img width="930" alt="Screenshot 2023-01-01 at 7 00 47 PM" src="https://user-images.githubusercontent.com/36140450/210180480-f79820b9-232a-4f9e-8607-14cd1e9b3fff.png">

