### PR TITLE
Нечувствительный к регистру эндпоинт юзеров

### DIFF
--- a/users/views/profile.py
+++ b/users/views/profile.py
@@ -25,7 +25,7 @@ def profile(request, user_slug):
     if user_slug == "me":
         return redirect("profile", request.me.slug, permanent=False)
 
-    user = get_object_or_404(User, slug=user_slug)
+    user = get_object_or_404(User, slug__iexact=user_slug)
 
     if user.moderation_status != User.MODERATION_STATUS_APPROVED and not request.me.is_moderator:
         # hide unverified users


### PR DESCRIPTION
УРЛы профилей будут открываться независимо от регистра: `https://vas3k.club/user/vas3k/` откроет тот же профиль, что и `https://vas3k.club/user/Vas3k/`

`slugify` регистронезависим, так что вроде ничего не должно сломаться.

Fixes #886