### PR TITLE
Add og:description to private weekly_digest page

### DIFF
--- a/frontend/html/auth/access_denied.html
+++ b/frontend/html/auth/access_denied.html
@@ -14,12 +14,12 @@
         <meta property="og:site_name" content="{{ settings.APP_NAME }}">
         <meta property="og:url" content="{{ settings.APP_HOST }}{% url "show_post" post.type post.slug %}">
         <meta property="og:type" content="article" />
-        <meta property="og:description" content="{{ post.description | truncatechars:100 }}">
+        <meta property="og:description" content="{% if post.metadata.og_description %}{{ post.metadata.og_description }} {% else %}{{ post.description | truncatechars:100 }}{% endif %}">
         <meta property="og:image" content="{% og_image post %}">
 
         <meta name="twitter:card" content="summary">
         <meta name="twitter:title" content="{% if post.prefix %}{{ post.prefix }} {% endif %}{{ post.title }} — {{ settings.APP_NAME }}">
-        <meta name="twitter:description" content="{{ post.description | truncatechars:100 }}">
+        <meta name="twitter:description" content="{% if post.metadata.og_description %}{{ post.metadata.og_description }} {% else %}{{ post.description | truncatechars:100 }}{% endif %}">
         <meta name="twitter:image" content="{% og_image post %}">
     {% endif %}
 {% endblock %}

--- a/frontend/html/emails/weekly.html
+++ b/frontend/html/emails/weekly.html
@@ -9,7 +9,8 @@
     <meta property="og:site_name" content="Вастрик.Клуб" />
     <meta property="og:title" content="Клубный журнал. Итоги недели. Выпуск #{{ issue_number }}" />
     <meta property="og:type" content="article" />
-    <meta property="og:description" content="На этой неделе у нас +{{ newbie_count }} {{ newbie_count|rupluralize:"новый член,новых члена,новых членов" }} Клуба. Всего за неделю написали {{ post_count }} {{ post_count | rupluralize:"пост,поста,постов" }}." />
+    <meta property="og:description" content="{{ og_description }}" />
+
     <meta property="og:image" content="{{ og_image_url }}" />
 {% endblock %}
 

--- a/frontend/html/emails/weekly_og_description.html
+++ b/frontend/html/emails/weekly_og_description.html
@@ -1,0 +1,1 @@
+{% load text_filters %}На этой неделе у нас +{{ newbie_count }} {{ newbie_count|rupluralize:"новый член,новых члена,новых членов" }} Клуба. Всего за неделю написали {{ post_count }} {{ post_count | rupluralize:"пост,поста,постов" }}.

--- a/notifications/digests.py
+++ b/notifications/digests.py
@@ -237,6 +237,11 @@ def generate_weekly_digest(no_footer=False):
         "ava": settings.OG_MACHINE_AUTHOR_LOGO
     })
 
+    og_description = render_to_string("emails/weekly_og_description.html", {
+        "newbie_count" : newbie_count,
+        "post_count": post_count,
+    })
+
     return render_to_string("emails/weekly.html", {
         "posts": posts,
         "comments": comments,
@@ -253,5 +258,6 @@ def generate_weekly_digest(no_footer=False):
         "issue_number": issue_number,
         "pro_tip": pro_tip,
         "is_footer_excluded": no_footer,
-        "og_image_url": f"{settings.OG_IMAGE_GENERATOR_URL}?{og_params}"
-    })
+        "og_image_url": f"{settings.OG_IMAGE_GENERATOR_URL}?{og_params}",
+        "og_description" : og_description,
+    }), og_description

--- a/notifications/management/commands/send_weekly_digest.py
+++ b/notifications/management/commands/send_weekly_digest.py
@@ -27,13 +27,13 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         # render digest using a special html endpoint
         try:
-            digest = generate_weekly_digest()
+            digest, _ = generate_weekly_digest()
         except NotFound:
             log.error("Weekly digest is empty")
             return
 
         # get a version without "unsubscribe" footer for posting on home page
-        digest_without_footer = generate_weekly_digest(no_footer=True)
+        digest_without_footer, og_description = generate_weekly_digest(no_footer=True)
 
         # save digest as a post
         issue = (datetime.utcnow() - settings.LAUNCH_DATE).days // 7
@@ -49,6 +49,7 @@ class Command(BaseCommand):
                 is_pinned_until=datetime.utcnow() + timedelta(days=1),
                 is_visible=True,
                 is_public=False,
+                metadata={"og_description" : og_description},
             )
         )
 

--- a/notifications/views.py
+++ b/notifications/views.py
@@ -104,7 +104,7 @@ def render_daily_digest(request, user_slug):
 
 def render_weekly_digest(request):
     try:
-        digest = generate_weekly_digest()
+        digest, _ = generate_weekly_digest()
     except NotFound:
         raise Http404()
 


### PR DESCRIPTION
og:description is not visible at access_denied page (which page is seen by telegram or twitter or face book)
So in this commit description is writting to post.metadata and rendering at access_denied.html