### PR TITLE
JPE url matching

### DIFF
--- a/common/regexp.py
+++ b/common/regexp.py
@@ -1,7 +1,7 @@
 import re
 
 USERNAME_RE = re.compile(r"(?:\s|\n|^)@([A-Za-z0-9_-]{3,})")
-IMAGE_RE = re.compile(r"(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|jpeg|gif|png)")
+IMAGE_RE = re.compile(r"(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|jpeg|jpe|gif|png)")
 VIDEO_RE = re.compile(r"(http(s?):)([/|.|\w|\s|-])*\.(?:mov|mp4)")
 YOUTUBE_RE = re.compile(
     (
@@ -10,7 +10,7 @@ YOUTUBE_RE = re.compile(
     )
 )
 TWITTER_RE = re.compile(r"(https?:\/\/twitter.com\/[a-zA-Z0-9_]+\/status\/[\d]+)")
-FAVICON_RE = re.compile(r"(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|jpeg|gif|png|ico)")
+FAVICON_RE = re.compile(r"(http(s?):)([/|.|\w|\s|-])*\.(?:jpg|jpeg|jpe|gif|png|ico)")
 
 EMOJI_RE = re.compile(
     "["


### PR DESCRIPTION
Pepic временами возвращает урлы картинок с расширением jpe, и в комментариях они не вставляются, потому что парсинг не распознает.