### PR TITLE
fix(): enable go to second level comments in battles

### DIFF
--- a/frontend/html/posts/show/battle.html
+++ b/frontend/html/posts/show/battle.html
@@ -86,7 +86,7 @@
 {% endblock %}
 
 {% block comments %}
-    <div class="post-comments" id="comments">
+    <div class="post-comments battle-comments" id="comments">
         <div class="comment-scroll-arrow-wrapper">
             <comment-scroll-arrow />
         </div>

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -88,6 +88,8 @@ export default {
                      ".post-comments-list > .replies > .reply.comment-is-new",
                      // Новые реплаи на втором уровне к старым реплаям без родительского комментария
                      ".post-comments-list > .replies > .reply:not(.comment-is-new) > .reply.comment-is-new",
+                     // Новые реплаи на втором уровне бэтлов
+                     ".post-comments-list > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
                  ].join()
              );
 

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -89,7 +89,7 @@ export default {
                      // Новые реплаи на втором уровне к старым реплаям без родительского комментария
                      ".post-comments-list > .replies > .reply:not(.comment-is-new) > .reply.comment-is-new",
                      // Новые реплаи на втором уровне бэтлов
-                     ".post-comments-list > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
+                     ".battle-comments .post-comments-list > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
                  ].join()
              );
 


### PR DESCRIPTION
#1070  In battles second level comments in fact are third levels, and go to new message skips them.