### PR TITLE
fix missing search icon on small screens

### DIFF
--- a/frontend/static/css/components/menu.css
+++ b/frontend/static/css/components/menu.css
@@ -37,6 +37,10 @@
         }
 
         @media only screen and (max-width : 570px) {
+            .menu-left {
+                min-width: auto;
+            }
+            
             .menu-burger {
                 display: block;
             }


### PR DESCRIPTION
iPhone 13 mini
<img width="360" src="https://user-images.githubusercontent.com/18095933/230034575-2402db85-25d8-4787-b442-5455f1ef8ba5.PNG">


<img width="1667" alt="image" src="https://user-images.githubusercontent.com/18095933/230035574-802a321f-a403-4bfc-bc7d-ae8b4c82ad67.png">
<img width="1667" alt="image" src="https://user-images.githubusercontent.com/18095933/230035687-2c5d7289-1de5-468c-a8f9-90560ef54a33.png">
