### PR TITLE
lazy load images

### DIFF
--- a/common/markdown/club_renderer.py
+++ b/common/markdown/club_renderer.py
@@ -70,7 +70,7 @@ class ClubRenderer(mistune.HTMLRenderer):
         if title in IMAGE_CSS_CLASSES:
             css_classes = IMAGE_CSS_CLASSES[title]
 
-        image_tag = f'<img src="{escape_html(src)}" alt="{escape_html(title)}">'
+        image_tag = f'<img loading="lazy" src="{escape_html(src)}" alt="{escape_html(title)}">'
         caption = f"<figcaption>{escape_html(title)}</figcaption>" if title else ""
         return f'<figure class="{css_classes}">{image_tag}{caption}</figure>'
 


### PR DESCRIPTION
### Проблема

По дефолту браузеры пытаются загрузить все картинки на странице одновременно. Кто пытался открыть ежемесячный мемопост с мобилки, понимает, о чём речь — браузер пыхтит, жрёт трафик и рендерит все мемы разом.

### Решение

Есть нативный способ грузить картинку лениво (то есть когда она попала или приблизилась к видимой части экрана). Это простой советский атрибут. Я применил его ко всем картинкам в клубе, чтобы особо не мудрить с пробрасыванием параметров. 
Подробнее про атрибут `loading="lazy"` можно прочитать [здесь](https://web.dev/browser-level-image-lazy-loading/)