### PR TITLE
fix(): mark battle comments as new

### DIFF
--- a/frontend/html/comments/types/battle.html
+++ b/frontend/html/comments/types/battle.html
@@ -5,7 +5,7 @@
 <div class="battle-comment-prefix battle-comment-prefix-side-{{ comment.metadata.battle.side }}">
     за «{{ comment.battle_side }}»
 </div>
-<div class="block comment comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
+<div class="block comment {% if comment.created_at > post_last_view_at %}comment-is-new{% endif %}  comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
     <div class="comment-header">
         <div class="comment-title">{{ comment.title | rutypography }}</div>
         <div  class="comment-type-battle-userinfo">

--- a/frontend/html/comments/types/battle.html
+++ b/frontend/html/comments/types/battle.html
@@ -5,7 +5,7 @@
 <div class="battle-comment-prefix battle-comment-prefix-side-{{ comment.metadata.battle.side }}">
     за «{{ comment.battle_side }}»
 </div>
-<div class="block comment {% if comment.created_at > post_last_view_at %}comment-is-new{% endif %}  comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
+<div class="block comment {% if comment.created_at > post_last_view_at %}comment-type-battle-is-new{% endif %}  comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
     <div class="comment-header">
         <div class="comment-title">{{ comment.title | rutypography }}</div>
         <div  class="comment-type-battle-userinfo">

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -90,6 +90,8 @@ export default {
                      ".post-comments-list > .replies > .reply:not(.comment-is-new) > .reply.comment-is-new",
                      // Новые реплаи на втором уровне бэтлов
                      ".battle-comments .post-comments-list > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
+                     // новые аргументы в бэтлах
+                     ".comment.comment-type-battle-is-new",
                  ].join()
              );
 


### PR DESCRIPTION
Родительский коммент aka мнение в батлах, тоже должен выделяться. Из минусов текущего pr'ы, он ломает цвет этого самого мнения, нужно либо поправить стили тогда выходит, либо добавлять не comment-is-new а другой класс.
@vas3k как лучше сделать? потому что серые мнения в батлах это какой то минус к ux'у