### PR TITLE
Добавил кастомизацию цвета скроллбара

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -4,6 +4,16 @@
     --normal-content-width: 800px;
 }
 
+::-webkit-scrollbar {
+    background-color: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+    background-color: var(--opposite-bg-color);
+    border-radius: var(--block-border-radius);
+    height: 40px;
+}
+
 .content {
     margin: 0 auto;
     max-width: var(--normal-content-width);


### PR DESCRIPTION
В темной теме скроллбар выглядел ужасно, добавил кастомизацию с цветами темы

Было:
<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1833101/236670182-100dedbc-9779-4867-ae2e-92a8f1a78052.png">

Стало:
<img width="1092" alt="image" src="https://user-images.githubusercontent.com/1833101/236670150-0dcb66a1-b659-4d85-851d-70ae8e04fb58.png">

В светлой теме
Было:
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/1833101/236670284-b5f5472c-712a-47e9-a2ac-728b4575ffb4.png">

Стало:
<img width="1010" alt="image" src="https://user-images.githubusercontent.com/1833101/236670317-a2709b08-18a5-45db-8473-14856b7d3c1e.png">
