### PR TITLE
fix: border-radius for .network-channel-badge

### DIFF
--- a/frontend/static/css/components/network.css
+++ b/frontend/static/css/components/network.css
@@ -65,7 +65,7 @@
                 top: 16px;
                 right: 16px;
                 font-size: 200%;
-                border-radius: 50%;
+                border-radius: 1em;
                 background-color: var(--bg-color);
                 line-height: 1em;
                 min-width: 1em;


### PR DESCRIPTION
before:
<img width="160" alt="before" src="https://github.com/vas3k/vas3k.club/assets/3152460/8bcc2e6d-21a2-4d75-9d7d-6a4ebbdede1f">


after:
<img width="145" alt="after" src="https://github.com/vas3k/vas3k.club/assets/3152460/8e348854-b9a1-48ff-9a4b-3ebd408941a5">

Текущая реализация корректно работает для беджей с одним эмодзи, но плывет при 2+.