### PR TITLE
fix: rework notify-subscription for authors (notifies for second layer and etc)

### DIFF
--- a/comments/tests/test_comments.py
+++ b/comments/tests/test_comments.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.test.client import RequestFactory
+from comments.views import create_comment
+from posts.models.subscriptions import PostSubscription
+
+from posts.tests.test_views import ModelCreator
+
+class TestComments(TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+        self.creator = ModelCreator()
+        self.user = self.creator.create_user()
+        self.post = self.creator.create_post(
+            is_visible=True,
+            is_public=True,
+        )
+
+    def test_is_subscription_not_downgraded(self):
+        comment_form = {"text": "-", "subscribe_to_post": True}
+        comment_request = self.rf.post((f"post/{self.post.id}/comment/create/", self.post.id),
+                                       data=comment_form)
+        comment_request.me = self.user
+        create_comment(comment_request, self.post.id)
+        subscription: PostSubscription = PostSubscription.objects.filter(user=self.user, post=self.post).qs
+        self.assertTrue(subscription.type == PostSubscription.TYPE_ALL_COMMENTS)
+

--- a/comments/views.py
+++ b/comments/views.py
@@ -60,8 +60,9 @@ def create_comment(request, post_slug):
             comment.save()
 
             # subscribe to top level comments
-            if form.cleaned_data.get("subscribe_to_post"):
-                PostSubscription.subscribe(request.me, post, type=PostSubscription.TYPE_TOP_LEVEL_ONLY)
+            if (form.cleaned_data.get("subscribe_to_post") and
+                not PostSubscription.objects.filter(user=request.me, post=post).exists()):
+                    PostSubscription.subscribe(request.me, post, type=PostSubscription.TYPE_TOP_LEVEL_ONLY)
 
             # update the shitload of counters :)
             request.me.update_last_activity()

--- a/comments/views.py
+++ b/comments/views.py
@@ -60,9 +60,9 @@ def create_comment(request, post_slug):
             comment.save()
 
             # subscribe to top level comments
-            if (form.cleaned_data.get("subscribe_to_post") and
-                not PostSubscription.objects.filter(user=request.me, post=post).exists()):
-                    PostSubscription.subscribe(request.me, post, type=PostSubscription.TYPE_TOP_LEVEL_ONLY)
+            is_sub = form.cleaned_data.get("subscribe_to_post")
+            if is_sub and not PostSubscription.objects.filter(user=request.me, post=post).exists():
+                PostSubscription.subscribe(request.me, post, PostSubscription.TYPE_TOP_LEVEL_ONLY)
 
             # update the shitload of counters :)
             request.me.update_last_activity()


### PR DESCRIPTION
**Проблема:** не приходят уведомления с новыми комментами 2 уровня и ниже для авторов поста 

**Что сделал:** 
    **1)** Добавил простую проверку на подписку, чтобы отправление нового коммента не понижало статус авторской подписки на комменты. 
То есть чтоб новые комменты от автора с помеченной галкой на подписку (внизу) не сбрасывали с
PostSubscription.type = Type.ALL_COMMENTS
до 
PostSubscription.type = Type.TOP_LEVEL_ONLY.
     <img width="450" alt="Снимок экрана 2023-06-30 в 21 24 55"  
      src="https://github.com/vas3k/vas3k.club/assets/91570054/253a1110-3bcb-440f-a868-7217b122ef72">

**2)** Написал пару тестов для этого.

**Проблема/Для обсуждения:** В текущей реализации у автора сохраняется подписка на все комменты всех уровней, пока он не отожмет _**верхнюю**_ галку подписи на комменты. Если он отожмет — возможности подписаться на все комменты в этом посте больше не будет.
<img width="864" alt="Снимок экрана 2023-06-30 в 21 40 58" src="https://github.com/vas3k/vas3k.club/assets/91570054/ace7a443-d566-44d3-82e7-11e89307388b">


 Подписаться на все комменты невозможно с нуля, только если ты автор поста и ничего не отжимал. 


Мб сделать так, чтобы верхняя галка отвечала за подписку на все комменты, а нижняя — подписку на все комменты 1 уровня? Ну или можно оставить этот вопрос для другого issue, конечно 

 closes #1029