### PR TITLE
Enable image uploading for mobile devices

### DIFF
--- a/frontend/static/js/components/CommentMarkdownEditor.vue
+++ b/frontend/static/js/components/CommentMarkdownEditor.vue
@@ -27,11 +27,12 @@ import { createMarkdownEditor, handleFormSubmissionShortcuts, imageUploadOptions
 
 export default {
     mounted() {
+        const $markdownElementDiv = this.$el.children[0];
         if (isMobile()) {
+            inlineAttachment.editors.input.attachToInput($markdownElementDiv, imageUploadOptions);
             return;
         }
 
-        const $markdownElementDiv = this.$el.children[0];
         this.editor = createMarkdownEditor($markdownElementDiv, {
             toolbar: false,
         });

--- a/frontend/static/js/input.inline-attachment.js
+++ b/frontend/static/js/input.inline-attachment.js
@@ -1,0 +1,48 @@
+/*jslint newcap: true */
+/*global inlineAttachment: false */
+(function() {
+  "use strict";
+
+  inlineAttachment.editors.input = {
+    Editor: function(instance) {
+
+      var input = instance;
+
+      return {
+        getValue: function() {
+          return input.value;
+        },
+        insertValue: function(val) {
+          inlineAttachment.util.insertTextAtCursor(input, val);
+        },
+        setValue: function(val) {
+          input.value = val;
+        }
+      };
+    },
+    attachToInput: function(input, options) {
+      options = options || {};
+
+      var editor = new inlineAttachment.editors.input.Editor(input),
+        inlineattach = new inlineAttachment(options, editor);
+
+      input.addEventListener("paste", function(e) {
+        inlineattach.onPaste(e);
+      }, false);
+      input.addEventListener("drop", function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+        inlineattach.onDrop(e);
+      }, false);
+      input.addEventListener("dragenter", function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+      }, false);
+      input.addEventListener("dragover", function(e) {
+        e.stopPropagation();
+        e.preventDefault();
+      }, false);
+    }
+  };
+
+})();

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -4,6 +4,7 @@ import "../css/index.css";
 
 import "./inline-attachment";
 import "./codemirror-4.inline-attachment";
+import "./input.inline-attachment";
 
 import App from "./App.js";
 import ClubApi from "./common/api.service.js";


### PR DESCRIPTION
Fast fix of #715.

I was able to upload images from iPhone using copy/paste and drag'n'drop from Files and Photos apps. Tested in Safari.
