### PR TITLE
Hide reply edit button for post's authors

### DIFF
--- a/frontend/html/comments/types/reply.html
+++ b/frontend/html/comments/types/reply.html
@@ -76,22 +76,22 @@
         </div>
         <div class="reply-footer thread-collapse-toggle">
             {% if me.id == comment.author_id or me.id == comment.post.author_id or me.is_moderator %}
-                {% if not comment.is_deleted or me.id == comment.deleted_by or me.is_moderator %}
-                    {% if comment.is_deleted %}
-                        <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button reply-button-hidden" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
-                    {% else %}
-                        <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button reply-button-hidden" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
-                    {% endif %}
+                {% if comment.is_deleted %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button reply-button-hidden" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
+                {% else %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button reply-button-hidden" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
                 {% endif %}
+            {% endif %}
 
+            {% if me.id == comment.author_id or me.is_moderator %}
                 <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button reply-button-hidden"><i class="fas fa-edit"></i></a>
             {% endif %}
 
-	    {% if me and me.is_active_membership and comment.post.is_commentable %}
-            <span class="comment-footer-button" v-on:click="showReplyForm('{{ reply_to.id }}', '{{ comment.author.slug }}', true)">
-                <i class="fas fa-reply"></i>&nbsp;ответить
-            </span>
-	    {% endif %}
+            {% if me and me.is_active_membership and comment.post.is_commentable %}
+                <span class="comment-footer-button" v-on:click="showReplyForm('{{ reply_to.id }}', '{{ comment.author.slug }}', true)">
+                    <i class="fas fa-reply"></i>&nbsp;ответить
+                </span>
+            {% endif %}
         </div>
         <div class="reply-replies thread-collapse-toggle">
             {% if replies %}


### PR DESCRIPTION
- пофексил баг, при котором кнопка "редактирования" для реплаев показывалась автором поста
- изменил рестрикшенсы для реплаев по аналогии с комментариями

До:
<img width="450" alt="Screenshot 2023-10-19 at 12 45 51 AM" src="https://github.com/vas3k/vas3k.club/assets/36140450/220d7686-c4f4-4395-96a3-48b25e71c735">

После:
<img width="450" alt="Screenshot 2023-10-19 at 12 44 30 AM" src="https://github.com/vas3k/vas3k.club/assets/36140450/810cbb09-462d-4de3-af9a-cfcfd61a8195">
