### PR TITLE
bugfix: TagSelect show only collectible tags

### DIFF
--- a/frontend/static/js/components/TagSelect.vue
+++ b/frontend/static/js/components/TagSelect.vue
@@ -161,10 +161,13 @@ export default {
                     if (!json.tags) {
                         return;
                     }
-                    vm.options = json.tags.map(tag => ({
-                        title: tag.name,
-                        isExist: true,
-                    }));
+                    vm.options = json.tags
+                        .filter(tag => tag.group === 'collectible')
+                        .map(tag => ({
+                            title: tag.name,
+                            isExist: true,
+                        }))
+                    ;
                 })
                 .finally(() => {
                     loading(false);


### PR DESCRIPTION
Add filter function to hide «standard» tags

Diff prod vs fix:
<img width="782" alt="image" src="https://github.com/vas3k/vas3k.club/assets/5501086/c4469ca7-ec8f-4131-a651-23491d20f9a8">

![image](https://github.com/vas3k/vas3k.club/assets/5501086/3eca2a59-7b6f-4c28-84a0-549332ce9e05)

