### PR TITLE
Hide scroll to comments button on printed version of the post page

### DIFF
--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -630,6 +630,12 @@
         transform: translateX(-50%) translateY(-50%) rotate(0);
     }
 
+    @media only print {
+        .comment-scroll-arrow {
+            display: none;
+        }
+    }
+
 .comment-markdown-editor {
     position: relative;
 }


### PR DESCRIPTION
On the printed version of the post page the scroll to comments button is appeared on each page of the document and sometimes overlap useful content of the page.
This PR hides the button if `@media print` is true.

BEFORE:
<img width="1190" alt="image" src="https://github.com/vas3k/vas3k.club/assets/525900/3309f6d4-c0c2-4fd0-af3b-d44e1b6a5149">

AFTER:
<img width="1186" alt="image" src="https://github.com/vas3k/vas3k.club/assets/525900/6c6ade41-e2ad-4a4a-824c-6e4ace978ea4">
