### PR TITLE
fix: load twemoji as a deferred script

### DIFF
--- a/frontend/html/common/js.html
+++ b/frontend/html/common/js.html
@@ -9,4 +9,4 @@
 {% render_bundle "main" "js" %}
 
 {# special hack for emoji support on windows/linux #}
-<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js" crossorigin="anonymous" async></script>
+<script src="https://cdn.jsdelivr.net/npm/@twemoji/api@latest/dist/twemoji.min.js" crossorigin="anonymous" defer></script>


### PR DESCRIPTION
"async" scripts are not bound to the DOMContentLoaded event, and we need `twemoji` to be loaded by the moment the app gets initialised. So, changing "async" to "defer".