### PR TITLE
bugfix: adjust comment form width to 100% to prevent overflow

### DIFF
--- a/frontend/static/css/layout.css
+++ b/frontend/static/css/layout.css
@@ -326,7 +326,7 @@
         }
 
             .comment-form-body-battle-side #id_battle_side {
-                width: auto;
+                width: 100%;
                 max-width: 60%;
             }
 


### PR DESCRIPTION
I am adding screenshots before and after adjusting comment form width to 100% to prevent overflow:

![after](https://github.com/vas3k/vas3k.club/assets/109278086/43bfcb67-6b34-4082-ab89-84b9b19ed119)
![before](https://github.com/vas3k/vas3k.club/assets/109278086/657e0833-b7e8-4ad2-b7f4-d2d6b9fc9771)
