### PR TITLE
fix: rss ignore `is_public` option

### DIFF
--- a/posts/rss.py
+++ b/posts/rss.py
@@ -24,4 +24,6 @@ class NewPostsRss(Feed):
         return title
 
     def item_description(self, item):
+        if not item.is_public:
+            return "🔒"
         return item.description


### PR DESCRIPTION
rss фид игнорил `is_public` флаг и публиковал контент приватных постов