### PR TITLE
Одна форма отправки ответов к комментариям

### DIFF
--- a/frontend/html/comments/list.html
+++ b/frontend/html/comments/list.html
@@ -9,8 +9,4 @@
     {% else %}
         {% include "comments/types/normal.html" with comment=tree.comment replies=tree.replies %}
     {% endif %}
-
-    {% if post.is_commentable and me %}
-        {% include "comments/forms/reply.html" with comment=tree.comment reply_form=reply_form %}
-    {% endif %}
 {% endfor %}

--- a/frontend/html/comments/types/battle.html
+++ b/frontend/html/comments/types/battle.html
@@ -2,71 +2,66 @@
 {% load text_filters %}
 {% load battle %}
 {% load posts %}
-<div class="battle-comment-prefix battle-comment-prefix-side-{{ comment.metadata.battle.side }}">
-    за «{{ comment.battle_side }}»
-</div>
-<div class="block comment comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}" id="comment-{{ comment.id }}">
-    <div class="comment-header">
-        <div class="comment-title">{{ comment.title | rutypography }}</div>
-        <div  class="comment-type-battle-userinfo">
-            {% include "users/widgets/tiny.html" with user=comment.author %}
+<div class="battle-comments-list" id="comment-{{ comment.id }}">
+    <div class="battle-comment-prefix battle-comment-prefix-side-{{ comment.metadata.battle.side }}">
+        за «{{ comment.battle_side }}»
+    </div>
+    <div class="block comment comment-type-battle comment-type-battle-side-{{ comment.metadata.battle.side }}">
+        <div class="comment-header">
+            <div class="comment-title">{{ comment.title | rutypography }}</div>
+            <div  class="comment-type-battle-userinfo">
+                {% include "users/widgets/tiny.html" with user=comment.author %}
 
-            <a href="#comment-{{ comment.id }}" class="reply-date">
-                {{ comment.created_at | cool_date }}
-            </a>
+                <a href="#comment-{{ comment.id }}" class="reply-date">
+                    {{ comment.created_at | cool_date }}
+                </a>
+            </div>
+        </div>
+        <div class="comment-rating">
+            <comment-upvote :initial-upvotes="{{ comment.upvotes }}"
+                             :hours-to-retract-vote="{{settings.RETRACT_VOTE_IN_HOURS}}"
+                             upvote-url="{% url "upvote_comment" comment.id %}"
+                             retract-vote-url="{% url "retract_comment_vote" comment.id %}"
+                             {% if comment.is_voted %}
+                                initial-is-voted
+                                initial-upvote-timestamp="{{comment.upvoted_at}}"
+                             {% endif %}
+                             {% if not me|can_upvote_comment:comment or upvote_disabled %}is-disabled{% endif %}>
+            </comment-upvote>
+
+            {% if comment.is_pinned %}
+                <div class="comment-pinned-icon"><i class="fas fa-thumbtack"></i></div>
+            {% endif %}
+        </div>
+        <div class="comment-body thread-collapse-toggle">
+            <div class="text-body text-body-type-comment">
+                {% render_comment comment %}
+            </div>
+        </div>
+        <div class="comment-footer thread-collapse-toggle">
+            {% if me.id == comment.author_id or me.id == comment.post.author_id or me.is_moderator %}
+                {% if comment.is_deleted %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
+                {% else %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
+                {% endif %}
+            {% endif %}
+
+            {% if me.id == comment.author_id or me.is_moderator %}
+                <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-edit"></i></a>
+            {% endif %}
+
+            {% if me and me.is_active_membership and comment.post.is_commentable %}
+                <span class="comment-footer-button" v-on:click="showReplyForm('{{ comment.id }}', '', true)"><i class="fas fa-reply"></i>&nbsp;ответить</span>
+            {% endif %}
         </div>
     </div>
-    <div class="comment-rating">
-        <comment-upvote :initial-upvotes="{{ comment.upvotes }}"
-                         :hours-to-retract-vote="{{settings.RETRACT_VOTE_IN_HOURS}}"
-                         upvote-url="{% url "upvote_comment" comment.id %}"
-                         retract-vote-url="{% url "retract_comment_vote" comment.id %}"
-                         {% if comment.is_voted %}
-                            initial-is-voted
-                            initial-upvote-timestamp="{{comment.upvoted_at}}"
-                         {% endif %}
-                         {% if not me|can_upvote_comment:comment or upvote_disabled %}is-disabled{% endif %}>
-        </comment-upvote>
 
-        {% if comment.is_pinned %}
-            <div class="comment-pinned-icon"><i class="fas fa-thumbtack"></i></div>
-        {% endif %}
-    </div>
-    <div class="comment-body thread-collapse-toggle">
-        <div class="text-body text-body-type-comment">
-            {% render_comment comment %}
+    {% if replies %}
+        <div class="replies replies-type-battle replies-indent-normal">
+            {% for reply_tree in replies %}
+                {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
+            {% endfor %}
         </div>
-    </div>
-    <div class="comment-footer thread-collapse-toggle">
-        {% if me.id == comment.author_id or me.id == comment.post.author_id or me.is_moderator %}
-            {% if comment.is_deleted %}
-                <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
-            {% else %}
-                <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
-            {% endif %}
-        {% endif %}
-
-        {% if me.id == comment.author_id or me.is_moderator %}
-            <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-edit"></i></a>
-        {% endif %}
-
-        {% if me and me.is_active_membership and comment.post.is_commentable %}
-            <span class="comment-footer-button" v-on:click="showReplyForm('{{ comment.id }}', '', true)"><i class="fas fa-reply"></i>&nbsp;ответить</span>
-        {% endif %}
-    </div>
+    {% endif %}
 </div>
-
-<div class="clearfix"></div>
-
-{% if replies %}
-    <div class="replies replies-indent-normal">
-        {% for reply_tree in replies %}
-            {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
-
-            {% if post.is_commentable and me %}
-                {% include "comments/forms/reply.html" with comment=reply_tree.comment reply_form=reply_form %}
-            {% endif %}
-        {% endfor %}
-    </div>
-    <div class="clearfix20"></div>
-{% endif %}

--- a/frontend/html/comments/types/bold.html
+++ b/frontend/html/comments/types/bold.html
@@ -1,107 +1,107 @@
 {% load text_filters %}
 {% load posts %}
 {% load comments %}
-<div class="block comment comment-layout-block {% if comment.metadata.badges %}comment-is-badged{% endif %}" id="comment-{{ comment.id }}">
-    <div class="comment-side">
-        <a class="avatar comment-side-avatar" href="{% url "profile" comment.author.slug %}">
-            <img src="{{ comment.author.get_avatar }}" alt="Аватар {{ comment.author.full_name }}" loading="lazy" />
-        </a>
-    </div>
-    <div class="comment-header">
-        <span class="comment-header-author-and-date">
-            <span class="comment-header-author">
-                <a
-                    href="{% url "profile" comment.author.slug %}"
-                    data-author-slug="{{ comment.author.slug }}"
-                    class="comment-header-author-name"
-                >
-                    {{ comment.author.full_name }}
-                </a>
-                {% if comment.author_id in user_notes %}
-                    <span class="comment-header-author-note">{{ user_notes|lookup:comment.author_id|truncatechars:128 }}</span>
-                {% else %}
-                    <span class="comment-header-author-position">{{ comment.author.position }}</span>
-                {% endif %}
-                {% if comment.author.hat %}{% include "users/widgets/hat.html" with hat=comment.author.hat %}{% endif %}
-                {% if comment.author == post.author %}{% include "users/widgets/hat_author.html" %}{% endif %}
-
-                {% if me and comment.author_id != me.id and not comment.author.deleted_at %}
-                    <a href="{% url "create_badge_for_comment" comment.id %}">
-                        <span class="comment-badge-button"><i class="fas fa-gift"></i></span>
+<div id="comment-{{ comment.id }}">
+    <div class="block comment comment-layout-block {% if comment.metadata.badges %}comment-is-badged{% endif %}">
+        <div class="comment-side">
+            <a class="avatar comment-side-avatar" href="{% url "profile" comment.author.slug %}">
+                <img src="{{ comment.author.get_avatar }}" alt="Аватар {{ comment.author.full_name }}" loading="lazy" />
+            </a>
+        </div>
+        <div class="comment-header">
+            <span class="comment-header-author-and-date">
+                <span class="comment-header-author">
+                    <a
+                        href="{% url "profile" comment.author.slug %}"
+                        data-author-slug="{{ comment.author.slug }}"
+                        class="comment-header-author-name"
+                    >
+                        {{ comment.author.full_name }}
                     </a>
-                {% endif %}
+                    {% if comment.author_id in user_notes %}
+                        <span class="comment-header-author-note">{{ user_notes|lookup:comment.author_id|truncatechars:128 }}</span>
+                    {% else %}
+                        <span class="comment-header-author-position">{{ comment.author.position }}</span>
+                    {% endif %}
+                    {% if comment.author.hat %}{% include "users/widgets/hat.html" with hat=comment.author.hat %}{% endif %}
+                    {% if comment.author == post.author %}{% include "users/widgets/hat_author.html" %}{% endif %}
+
+                    {% if me and comment.author_id != me.id and not comment.author.deleted_at %}
+                        <a href="{% url "create_badge_for_comment" comment.id %}">
+                            <span class="comment-badge-button"><i class="fas fa-gift"></i></span>
+                        </a>
+                    {% endif %}
+                </span>
+
+                <a class="comment-header-date" href="{% url "show_post" comment.post.type comment.post.slug %}#comment-{{ comment.id }}">
+                    {{ comment.created_at | cool_date }}
+                </a>
             </span>
 
-            <a class="comment-header-date" href="{% url "show_post" comment.post.type comment.post.slug %}#comment-{{ comment.id }}">
-                {{ comment.created_at | cool_date }}
-            </a>
-        </span>
+            <div class="comment-header-badges">
+                {% if comment.metadata.badges %}
+                    <div class="comment-badges">
+                        {% include "badges/widgets/badges.html" with badges=comment.metadata.badges %}
+                    </div>
 
-        <div class="comment-header-badges">
-            {% if comment.metadata.badges %}
-                <div class="comment-badges">
-                    {% include "badges/widgets/badges.html" with badges=comment.metadata.badges %}
-                </div>
+                    {% if me and comment.author_id != me.id and not comment.author.deleted_at %}
+                        <a class="comment-badge-button" href="{% url "create_badge_for_comment" comment.id %}">
+                            <i class="fas fa-gift"></i>
+                        </a>
+                    {% endif %}
+                {% endif %}
+            </div>
+        </div>
+        <div class="comment-rating">
+            <comment-upvote :initial-upvotes="{{ comment.upvotes }}"
+                             :hours-to-retract-vote="{{settings.RETRACT_VOTE_IN_HOURS}}"
+                             upvote-url="{% url "upvote_comment" comment.id %}"
+                             retract-vote-url="{% url "retract_comment_vote" comment.id %}"
+                             {% if comment.is_voted %}
+                                initial-is-voted
+                                initial-upvote-timestamp="{{comment.upvoted_at}}"
+                             {% endif %}
+                             {% if not me|can_upvote_comment:comment or upvote_disabled %}is-disabled{% endif %}>
+            </comment-upvote>
 
-                {% if me and comment.author_id != me.id and not comment.author.deleted_at %}
-                    <a class="comment-badge-button" href="{% url "create_badge_for_comment" comment.id %}">
-                        <i class="fas fa-gift"></i>
-                    </a>
+            {% if comment.is_pinned %}
+                <div class="comment-pinned-icon"><i class="fas fa-thumbtack"></i></div>
+            {% endif %}
+        </div>
+        <div class="comment-body">
+            <div class="text-body text-body-type-comment">
+                {% render_comment comment %}
+            </div>
+        </div>
+        <div class="comment-footer">
+            {% if me.id == comment.post.author_id or me.is_moderator %}
+                <a href="{% url "pin_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-thumbtack"></i></a>
+            {% endif %}
+
+            {% if me.id == comment.author_id or me.id == comment.post.author_id or me.is_moderator %}
+                {% if comment.is_deleted %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
+                {% else %}
+                    <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
                 {% endif %}
             {% endif %}
-        </div>
-    </div>
-    <div class="comment-rating">
-        <comment-upvote :initial-upvotes="{{ comment.upvotes }}"
-                         :hours-to-retract-vote="{{settings.RETRACT_VOTE_IN_HOURS}}"
-                         upvote-url="{% url "upvote_comment" comment.id %}"
-                         retract-vote-url="{% url "retract_comment_vote" comment.id %}"
-                         {% if comment.is_voted %}
-                            initial-is-voted
-                            initial-upvote-timestamp="{{comment.upvoted_at}}"
-                         {% endif %}
-                         {% if not me|can_upvote_comment:comment or upvote_disabled %}is-disabled{% endif %}>
-        </comment-upvote>
 
-        {% if comment.is_pinned %}
-            <div class="comment-pinned-icon"><i class="fas fa-thumbtack"></i></div>
-        {% endif %}
-    </div>
-    <div class="comment-body">
-        <div class="text-body text-body-type-comment">
-            {% render_comment comment %}
-        </div>
-    </div>
-    <div class="comment-footer">
-        {% if me.id == comment.post.author_id or me.is_moderator %}
-            <a href="{% url "pin_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-thumbtack"></i></a>
-        {% endif %}
-
-        {% if me.id == comment.author_id or me.id == comment.post.author_id or me.is_moderator %}
-            {% if comment.is_deleted %}
-                <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Восстанавливаем?')"><i class="fas fa-trash-restore"></i></a>
-            {% else %}
-                <a href="{% url "delete_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover" onclick="return confirm('Удаляем?')"><i class="fas fa-trash"></i></a>
+            {% if me.id == comment.author_id or me.is_moderator %}
+                <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-edit"></i></a>
             {% endif %}
-        {% endif %}
 
-        {% if me.id == comment.author_id or me.is_moderator %}
-            <a href="{% url "edit_comment" comment.id %}" class="comment-footer-button comment-button-visible-on-hover"><i class="fas fa-edit"></i></a>
-        {% endif %}
-
-        {% if me and me.is_active_membership and comment.post.is_commentable %}
-            <span class="comment-footer-button" v-on:click="showReplyForm('{{ comment.id }}', '{{ comment.author.slug }}', true)"><i class="fas fa-reply"></i>&nbsp;ответить</span>
-        {% endif %}
+            {% if me and me.is_active_membership and comment.post.is_commentable %}
+                <span class="comment-footer-button" v-on:click="showReplyForm('{{ comment.id }}', '{{ comment.author.slug }}', true)"><i class="fas fa-reply"></i>&nbsp;ответить</span>
+            {% endif %}
+        </div>
     </div>
-</div>
 
-<div class="clearfix"></div>
-
-{% if replies %}
-<div class="replies replies-indent-normal">
-    {% for reply_tree in replies %}
-        {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
-    {% endfor %}
+    {% if replies %}
+        <div class="replies replies-indent-normal">
+            {% for reply_tree in replies %}
+                {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
+            {% endfor %}
+        </div>
+        <div class="clearfix20"></div>
+    {% endif %}
 </div>
-<div class="clearfix20"></div>
-{% endif %}

--- a/frontend/html/comments/types/bold.html
+++ b/frontend/html/comments/types/bold.html
@@ -101,10 +101,6 @@
 <div class="replies replies-indent-normal">
     {% for reply_tree in replies %}
         {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
-
-        {% if post.is_commentable and me %}
-            {% include "comments/forms/reply.html" with comment=reply_tree.comment reply_form=reply_form %}
-        {% endif %}
     {% endfor %}
 </div>
 <div class="clearfix20"></div>

--- a/frontend/html/comments/types/normal.html
+++ b/frontend/html/comments/types/normal.html
@@ -113,10 +113,6 @@
             <div class="replies">
                 {% for reply_tree in replies %}
                     {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
-
-                    {% if post.is_commentable and me %}
-                        {% include "comments/forms/reply.html" with comment=reply_tree.comment reply_form=reply_form %}
-                    {% endif %}
                 {% endfor %}
             </div>
             <div class="clearfix20"></div>

--- a/frontend/html/posts/show/battle.html
+++ b/frontend/html/posts/show/battle.html
@@ -107,9 +107,21 @@
         {% endif %}
 
         {% if comments %}
+            {% if post.is_commentable and me %}
+                <reply-container
+                    :reply-to="replyTo"
+                    comment-order="{{ comment_order }}"
+                    avatar-url="{{ me.get_avatar }}"
+                    username="{{ me.full_name }}"
+                    create-comment-url="{% url "create_comment" post.slug %}"
+                >
+            {% endif %}
             <div class="post-comments-list">
                 {% include "comments/list.html" with comments=comments reply_form=reply_form type="battle" %}
             </div>
+            {% if post.is_commentable and me %}
+                </reply-container>
+            {% endif %}
         {% endif %}
 
         {% if me and me.is_active_membership and post.is_commentable and post.is_visible or me.is_moderator %}

--- a/frontend/html/posts/show/layout.html
+++ b/frontend/html/posts/show/layout.html
@@ -76,9 +76,23 @@
                 </div>
 
                 {% if comments %}
+                    {% if post.is_commentable and me %}
+                        <reply-container
+                            :reply-to="replyTo"
+                            comment-order="{{ comment_order }}"
+                            avatar-url="{{ me.get_avatar }}"
+                            username="{{ me.full_name }}"
+                            create-comment-url="{% url "create_comment" post.slug %}"
+                        >
+                    {% endif %}
+
                     <div class="post-comments-list">
                         {% include "comments/list.html" with comments=comments reply_form=reply_form type="normal" muted_user_ids=muted_user_ids %}
                     </div>
+
+                    {% if post.is_commentable and me %}
+                        </reply-container>
+                    {% endif %}
                 {% endif %}
 
                 {% if me and me.is_active_membership and post.is_commentable and post.is_visible or me.is_moderator %}

--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -57,6 +57,10 @@
         padding: 0 20px;
     }
 
+    .reply-form-form {
+        scroll-margin-top: 20px;
+    }
+
 .reply-form {
     margin-top: 0;
     margin-left: 25px;
@@ -433,6 +437,9 @@
 
         .comment-type-battle-side-a {
             background: rgba(76, 152, 213, 0.3);
+            /* from left border to the end of the center column */
+            grid-area: auto / left-start / auto / center-end;
+            justify-self: start;
         }
 
             .comment-type-battle-side-a:target {
@@ -445,6 +452,9 @@
 
         .comment-type-battle-side-b {
             background: rgba(83, 170, 104, 0.3);
+            /* from center column to the end of the right column */
+            grid-area: auto / center-start / auto / right-end;
+            justify-self: end;
         }
 
             .comment-type-battle-side-b:target {
@@ -464,6 +474,7 @@
         top: 0.7em;
         opacity: 0.5;
         font-weight: 500;
+        grid-area: prefix;
     }
 
         .battle-comment-prefix-side-a {
@@ -474,6 +485,10 @@
             color: #53AA68;
             text-align: right;
         }
+
+    .replies-type-battle {
+        grid-area: replies;
+    }
 
 .reply {
     margin: 10px 0 15px 0;

--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -1007,6 +1007,15 @@
             }
         }
 
+    .battle-comments-list {
+        display: grid;
+        grid-template-columns: 10% 1fr 10%;
+        grid-template-areas:
+            "prefix prefix prefix"
+            "left center right"
+            "replies replies replies"
+    }
+
     .post-comments-form {
         padding-top: 30px;
         padding-left: 10px;

--- a/frontend/static/js/components/CommentMarkdownEditor.vue
+++ b/frontend/static/js/components/CommentMarkdownEditor.vue
@@ -57,7 +57,6 @@ export default {
     data() {
         return {
             selectedUserIndex: null,
-            postSlug: null,
             users: [],
             autocomplete: null,
             autocompleteCache: {

--- a/frontend/static/js/components/ReplyContainer.vue
+++ b/frontend/static/js/components/ReplyContainer.vue
@@ -1,0 +1,133 @@
+<template>
+    <div>
+        <form method="post" :action="createCommentUrl" class="form reply-form-form" id="comment-reply-form" v-if="replyTo !== null">
+            <input type="hidden" name="post_comment_order" :value="commentOrder">
+            <input type="hidden" name="reply_to_id" :value="replyTo.commentId">
+
+            <div class="reply-form">
+                <div class="reply-form-avatar">
+                    <div class="avatar"><img :src="avatarUrl" :alt="avatarAlt" loading="lazy" /></div>
+                </div>
+
+                <div class="reply-form-body">
+                    <comment-markdown-editor>
+                        <textarea name="text" maxlength="20000" placeholder="Напишите ответ..." class="markdown-editor-invisible" required>
+                        </textarea>
+                    </comment-markdown-editor>
+                </div>
+
+                <div class="reply-form-button">
+                    <button type="submit" class="button button-small">Отправить</button>
+                </div>
+            </div>
+        </form>
+
+        <slot></slot>
+    </div>
+</template>
+
+<script>
+export default {
+    name: 'ReplyContainer',
+    props: ["replyTo", "commentOrder", "avatarUrl", "username", "createCommentUrl"],
+    computed: {
+        avatarAlt: function() {
+            return `Аватар ${this.$props.username}`
+        }
+    },
+    data: function () {
+        return {
+            drafts: {},
+            editor: undefined
+        }
+    },
+    watch: {
+        replyTo: async function(newReplyTo, oldReplyTo) {
+            this.replyTo = newReplyTo;
+            if (oldReplyTo) {
+                this.saveDraft(oldReplyTo.commentId);
+            }
+        }
+    },
+    updated: function() {
+        if (this.replyTo !== null && this.getEditor()) {
+            // move the reply form under the comment
+            const replyForm = this.$el.querySelector("#comment-reply-form")
+            const newCommentEl = this.$el.querySelector(`#comment-${this.replyTo.commentId}`)
+            newCommentEl.after(replyForm)
+            const editor = this.getEditor()
+
+            if (this.replyTo.commentId in this.drafts) {
+                const text = this.drafts[this.replyTo.commentId]
+                const textarea = replyForm.querySelector("textarea")
+                textarea.value = text
+                editor.setValue(text)
+            } else {
+                this.getEditor().setValue("")
+                // Add username to reply
+                const username = this.replyTo.username
+                if (username !== null && username !== "") {
+                    this.appendMarkdownTextareaValue("@" + username + ", ");
+                }
+
+                // Add selected text as quote
+                const withSelection = this.replyTo.withSelection
+                if (withSelection) {
+                    const selectedText = window.getSelection().toString();
+                    if (selectedText !== null && selectedText !== "") {
+                        this.appendMarkdownTextareaValue("\n> " + selectedText + "\n\n");
+                    }
+                }
+
+                this.appendMarkdownTextareaValue("");
+            }
+
+            editor.focus()
+            editor.execCommand("goDocEnd")
+
+            replyForm.scrollIntoView({behavior: "smooth", block: "center"})
+        }
+    },
+    methods: {
+        appendMarkdownTextareaValue: function(value) {
+            const textarea = this.$el.querySelector("#comment-reply-form textarea")
+            textarea.focus(); // on mobile
+            textarea.value = textarea.value + value;
+
+            const editor = this.getEditor()
+            if (editor) {
+                editor.setValue(editor.getValue() + value);
+            }
+        },
+        saveDraft: function(commentId) {
+            const editor = this.getEditor()
+            const text = editor.getValue()
+            if (editor && text.length > 0) {
+                this.drafts[commentId] = editor.getValue();
+            }
+        },
+        getEditor: function() {
+            if (!this.editor) {
+                const textarea = this.$el.querySelector("#comment-reply-form textarea")
+
+                textarea.focus(); // on mobile
+                if (!textarea.nextElementSibling) {
+                    console.error(`Couldn't find CodeMirror editor for ${textarea}`)
+                    return
+                }
+
+                const codeMirrorEditor = textarea.nextElementSibling.CodeMirror ||
+                    textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
+
+                if (codeMirrorEditor === undefined) {
+                    console.error(`Couldn't find CodeMirror editor for ${textarea}`)
+                }
+
+                this.editor = codeMirrorEditor
+            }
+
+            return this.editor
+        }
+    }
+}
+</script>

--- a/frontend/static/js/components/ReplyContainer.vue
+++ b/frontend/static/js/components/ReplyContainer.vue
@@ -29,7 +29,27 @@
 <script>
 export default {
     name: 'ReplyContainer',
-    props: ["replyTo", "commentOrder", "avatarUrl", "username", "createCommentUrl"],
+    props: {
+        replyTo: {
+            type: Object
+        },
+        commentOrder: {
+            type: String,
+            required: true
+        },
+        avatarUrl: {
+            type: String,
+            required: true
+        },
+        username: {
+            type: String,
+            required: true
+        },
+        createCommentUrl: {
+            type: String,
+            required: true
+        },
+    },
     computed: {
         avatarAlt: function() {
             return `Аватар ${this.$props.username}`

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -27,6 +27,7 @@ Vue.component("comment-markdown-editor", () => import("./components/CommentMarkd
 Vue.component("v-select", vSelect);
 Vue.component("tag-select", () => import("./components/TagSelect.vue"));
 Vue.component("simple-select", () => import("./components/SimpleSelect.vue"));
+Vue.component("reply-container", () => import("./components/ReplyContainer.vue"));
 
 // Since our pages have user-generated content, any fool can insert "{{" on the page and break it.
 // We have no other choice but to completely turn off template matching and leave it on only for components.
@@ -43,6 +44,7 @@ new Vue({
     },
     data: {
         shownWindow: null,
+        replyTo: null,
     },
     methods: {
         toggleCommentThread(event) {
@@ -75,51 +77,7 @@ new Vue({
             }
         },
         showReplyForm(commentId, username, withSelection) {
-            // First, hide all other reply forms
-            const replyForms = document.querySelectorAll(".reply-form-form");
-            for (let i = 0; i < replyForms.length; i++) {
-                // replyForms[i].removeEventListener('keydown', handleCommentHotkey); // FIXME???
-                replyForms[i].style.display = "none";
-            }
-
-            // Then show one for commentId
-            const commentReplyForm = document.getElementById("reply-form-" + commentId);
-            // commentReplyForm.addEventListener('keydown', (event) => handleCommentHotkey(event, commentReplyForm));  // FIXME???
-            commentReplyForm.style.display = null;
-
-            // Define helper function
-            function appendMarkdownTextareaValue(textarea, value) {
-                textarea.focus(); // on mobile
-                textarea.value = textarea.value + value;
-
-                // On mobile the next element sibling is undefined
-                if (textarea.nextElementSibling) {
-                    const codeMirrorEditor =
-                        textarea.nextElementSibling.CodeMirror ||
-                        textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
-                    if (codeMirrorEditor !== undefined) {
-                        codeMirrorEditor.setValue(codeMirrorEditor.getValue() + value);
-                        codeMirrorEditor.focus();
-                        codeMirrorEditor.setCursor(codeMirrorEditor.lineCount(), 0);
-                    }
-                }
-            }
-
-            // Add username to reply
-            const commentReplyTextarea = commentReplyForm.querySelector("textarea");
-            if (username !== null && username !== "") {
-                appendMarkdownTextareaValue(commentReplyTextarea, "@" + username + ", ");
-            }
-
-            // Add selected text as quote
-            if (withSelection) {
-                const selectedText = window.getSelection().toString();
-                if (selectedText !== null && selectedText !== "") {
-                    appendMarkdownTextareaValue(commentReplyTextarea, "\n> " + selectedText + "\n\n");
-                }
-            }
-
-            appendMarkdownTextareaValue(commentReplyTextarea, "");
+            this.replyTo = { commentId, username, withSelection }
         },
     },
 });


### PR DESCRIPTION
## Что

Использует одну форму отправки ответов к комментариям вместо того, чтобы создавать скрытую форму ответа для каждого комментария

[Демка в loom](https://www.loom.com/share/e2df4464a1cb4abf9233206507bc8e66) (звук так себе получился, сорян)

## Зачем

Мы генерим много форм, из которых используется только одна. Ожидаем, что размер страницы уменьшится и браузеру станет полегче. 

Сейчас есть такие темы:
- https://vas3k.club/question/5/ - 346 комментария, страница 131Kb, 290 форм ответов
- https://vas3k.club/thread/10298/ - 580 комментартев, страница 225Kb, 331 форма ответов

## Как

1. Все комментарии завернуты в новый vue компонент `ReplyContainer`. Он содержит форму ответа на комментарии.
2. При клике на "отправить" контейнер получает айди комментария и переносит единственную форму под блок этого комментария (пришлось переделать верстку, чтобы этот подход не создавал непонятных состояний)
3. Форма отправляется как и раньше

Closes #1210 