### PR TITLE
Фиксит сохранение неотправленных ответов

### DIFF
--- a/frontend/html/comments/types/reply.html
+++ b/frontend/html/comments/types/reply.html
@@ -88,7 +88,7 @@
             {% endif %}
 
             {% if me and me.is_active_membership and comment.post.is_commentable %}
-                <span class="comment-footer-button" v-on:click="showReplyForm('{{ reply_to.id }}', '{{ comment.author.slug }}')">
+                <span class="comment-footer-button" v-on:click="showReplyForm('{{ reply_to.id }}', '{{ comment.author.slug }}', '{{ comment.id }}')">
                     <i class="fas fa-reply"></i>&nbsp;ответить
                 </span>
             {% endif %}

--- a/frontend/static/js/components/ReplyContainer.vue
+++ b/frontend/static/js/components/ReplyContainer.vue
@@ -30,6 +30,7 @@
 export default {
     name: 'ReplyContainer',
     props: {
+        // type { commentId: string, username: string, draftKey?: string }
         replyTo: {
             type: Object
         },
@@ -65,7 +66,7 @@ export default {
         replyTo: async function(newReplyTo, oldReplyTo) {
             this.replyTo = newReplyTo;
             if (oldReplyTo) {
-                this.saveDraft(oldReplyTo.commentId);
+                this.saveDraft(getDraftKey(oldReplyTo));
             }
         }
     },
@@ -76,9 +77,10 @@ export default {
             const newCommentEl = this.$el.querySelector(`#comment-${this.replyTo.commentId}`)
             newCommentEl.after(replyForm)
             const editor = this.getEditor()
+            const draftKey = getDraftKey(this.replyTo)
 
-            if (this.replyTo.commentId in this.drafts) {
-                const text = this.drafts[this.replyTo.commentId]
+            if (draftKey in this.drafts) {
+                const text = this.drafts[draftKey]
                 const textarea = replyForm.querySelector("textarea")
                 textarea.value = text
                 editor.setValue(text)
@@ -138,5 +140,9 @@ export default {
             return this.editor
         }
     }
+}
+
+function getDraftKey(replyTo) {
+    return replyTo?.draftKey || replyTo?.commentId
 }
 </script>

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -76,8 +76,8 @@ new Vue({
                 window.scrollBy(0, commentPosition.top);
             }
         },
-        showReplyForm(commentId, username) {
-            this.replyTo = { commentId, username }
+        showReplyForm(commentId, username, draftKey) {
+            this.replyTo = { commentId, username, draftKey }
         },
     },
 });


### PR DESCRIPTION
## Что

Исправляет баг, когда форма отправки комментария показывает имя другого пользователя.

## Почему

Новой форма отправки ответов на комментарии (#1216) сохраняет написанный, но неотправленный комментарий. Для сохранения она использует айдишник комментария, на который отправляется ответ. 

Проблема была в том, что на последнем уровне глубины мы отправляем ответ не на текущий комментарий, а на родительский:
![CleanShot 2024-06-27 at 15 56 23@2x](https://github.com/vas3k/vas3k.club/assets/1469636/a65c4f8f-cfc5-4208-ba3f-f65cf91623eb)

Возникает коллизия ключей и сохраненный ответ к другому комментария достается из памяти.

## Как

Добавил опциональный ключ, который отправляется при ответе на комментарии последнего уровня.