### PR TITLE
Скрипт клонирования форков с блекджеком и куртизанками

### DIFF
--- a/etc/bin/clone-fork.sh
+++ b/etc/bin/clone-fork.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+repository="$1"
+directory="$2"
+
+# проверяем репу
+regex="^(https:\/\/github\.com\/([a-z0-9_-]+)\/vas3k\.club\/tree\/([^$]+)|([a-z0-9_]+):([^$]+))$"
+
+if [[ ! $repository =~ $regex ]]; then
+    echo "usage: clone-fork.sh \$repository \$directory"
+    echo ""
+    echo "repository -- full link to fork or fork name"
+    echo "directory -- local directory to clone (default is \$developer/\$branch)"
+    echo ""
+    echo "samples:"
+    echo "./clone-fork.sh trin4ik:feature/import-posts-to-dev ./"
+    echo "./clone-fork.sh https://github.com/trin4ik/vas3k.club/tree/feature/import-posts-to-dev"
+    exit
+fi
+
+developer=${BASH_REMATCH[2]}
+if [[ -z "$developer" ]]; then
+    developer=${BASH_REMATCH[4]}
+fi
+
+branch=${BASH_REMATCH[3]}
+if [[ -z "$branch" ]]; then
+    branch=${BASH_REMATCH[5]}
+fi
+
+if [[ $(curl -s -I -o /dev/null -w "%{http_code}" https://github.com/${developer}/vas3k.club/tree/${branch}) != "200" ]]; then
+    echo "error: repository does not exist"
+    exit
+fi
+
+if [[ -z $directory ]]; then
+    directory="${developer}/${branch}"
+fi
+
+echo "developer: ${developer}"
+echo "branch: ${branch}"
+
+echo "create directory"
+mkdir -p ${directory}
+
+# клонируем репу
+echo "cloning repository..."
+git clone --branch ${branch} --single-branch https://github.com/${developer}/vas3k.club ${directory}
+
+# меняем docker-compose
+echo "change docker-compose.yml"
+file="$(pwd)/${directory}/docker-compose.yml"
+default_name="vas3kclub"
+fork="${developer}/${branch}"
+postfix=$(echo "$fork" | sed -r 's/[\/-]/_/g')
+exists_name=$(grep -e '^name:' "$file" | awk '{ gsub(/"/, "", $2); print $2 }')
+
+# создаём или меняем имя проекта
+if [[ $exists_name ]]; then
+    sed -i -e "s/^name:.*/name: \"${exists_name}_${postfix}\"/g" $file
+else
+    sed -i "1s/^/name: \"${default_name}_${postfix}\"\n/" $file
+fi
+
+# меняем `container_name`
+while IFS= read -r line
+do
+    if [[ $line =~ ^([[:space:]]*)container_name:\ [^\n]+ ]]; then
+        new_line="${BASH_REMATCH[1]}$(echo "$line" | awk -v postfix="$postfix" '{ gsub(/"/, "", $2); print $1" "$2"_"postfix }')"
+        sed -i "s@${line}@${new_line}@" $file
+    fi
+done < $file
+
+echo "done"


### PR DESCRIPTION
## Проблема
Клон форков для проверки/ревью задача не сложная, но каждый раз приходится менять руками в композе имена контейнеров, чтобы они не конфликтовали с другими форками, уже запущенными. 
Не то, чтобы это прям частая задача, но хотелось бы автоматизировать

## Решение
bash скрипт, который всё это дело автоматизирует. 

```bash
$ curl -s https://raw.githubusercontent.com/trin4ik/vas3k.club/feature/clone-forks/etc/bin/clone-fork.sh | bash -s -- nlopin:feat/add-attach-file-button
developer: nlopin
branch: feat/add-attach-file-button
create directory
cloning repository...
Cloning into 'nlopin/feat/add-attach-file-button'...
remote: Enumerating objects: 13924, done.
remote: Counting objects: 100% (494/494), done.
remote: Compressing objects: 100% (234/234), done.
remote: Total 13924 (delta 277), reused 401 (delta 245), pack-reused 13430
Receiving objects: 100% (13924/13924), 16.84 MiB | 19.76 MiB/s, done.
Resolving deltas: 100% (9722/9722), done.
change docker-compose.yml
done
```
```bash
$ tree -d
.
├── nlopin
│   └── feat
│       └── add-attach-file-button
│           ├── authn
│           │   ├── context_processors
│           │   ├── decorators
│           │   ├── management
│           │   │   └── commands
│           │   ├── migrations
│           │   ├── models
│           │   ├── providers
│           │   └── views
│           ├── badges
│           │   └── migrations
│           ├── bookmarks
│           │   └── migrations
│           ├── bot
│           │   └── handlers
...
```
```bash
$ cat nlopin/feat/add-attach-file-button/docker-compose.yml
name: "vas3kclub_nlopin_feat_add_attach_file_button" # <---
version: "3.7"

services:
  club_app: &app
    container_name: club_app_nlopin_feat_add_attach_file_button # <---

...

  postgres:
    image: postgres:11
    container_name: club_postgres_nlopin_feat_add_attach_file_button # <---

...
```

Собственно, сам скрипт тут https://raw.githubusercontent.com/trin4ik/vas3k.club/feature/clone-forks/etc/bin/clone-fork.sh на вход 2 аргумента: репозиторий для клона в одном из форматов:
- `nlopin:feat/add-attach-file-button`
- `https://github.com/nlopin/vas3k.club/tree/feat/add-attach-file-button`

и второй аргумент -- директория для клона. По дефолту директория берётся `${developer}/${branch}`, для для репы https://github.com/nlopin/vas3k.club/tree/feat/add-attach-file-button будет создана директория `nlopin/feat/add-attach-file-button`

---

В целом не думаю, что это прям нужно тащить в основной проект, скрипт вполне может жить и в форке. Если решим перетащить в проект, то надо ещё описание для девелоперов написать. Запуск тоже не то, чтобы прям удобный
```bash
curl -s https://raw.githubusercontent.com/trin4ik/vas3k.club/feature/clone-forks/etc/bin/clone-fork.sh | bash -s -- nlopin:feat/add-attach-file-button
```
Но всё равно удобней, чем ковырять руками. 

---

Совсем крутым решением было бы сделать поддомен с генерацией скрипта, чтобы можно было делать
```bash
curl -s https://clone.vas3k.club/nlopin:feat/add-attach-file-button | bash
```
Вот это вообще секс ) Скопировал название PR, написал в консоли курл и вуаля. Что думаете?