### PR TITLE
Разделяет код мобильного и десктопного редакторов

### DIFF
--- a/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
@@ -52,9 +52,7 @@ export default {
 
         this.editor.codemirror.on("change", this.handleAutocompleteHintTrigger);
         this.editor.codemirror.on("change", this.handleSuggest);
-        this.editor.codemirror.on("blur", (editor, event) => {
-            this.$emit("blur", editor.getValue())
-        })
+        this.editor.codemirror.on("blur", this.emitCustomBlur)
 
         this.populateCacheWithCommentAuthors();
 
@@ -252,6 +250,9 @@ export default {
                     this.editor.codemirror.execCommand("goDocEnd")
                 }
             })
+        },
+        emitCustomBlur: function (editor) {
+            this.$emit("blur", editor.getValue())
         }
     },
 };

--- a/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
@@ -22,8 +22,8 @@
 </template>
 
 <script>
-import { throttle } from "../common/utils";
-import { createMarkdownEditor, handleFormSubmissionShortcuts, imageUploadOptions } from "../common/markdown-editor";
+import { throttle } from "../../common/utils";
+import { createMarkdownEditor, handleFormSubmissionShortcuts, imageUploadOptions } from "../../common/markdown-editor";
 
 export default {
     mounted() {

--- a/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/DesktopMarkdownEditor.vue
@@ -52,15 +52,15 @@ export default {
 
         this.editor.codemirror.on("change", this.handleAutocompleteHintTrigger);
         this.editor.codemirror.on("change", this.handleSuggest);
-        this.editor.codemirror.on("blur", this.emitCustomBlur)
+        this.editor.codemirror.on("blur", this.emitCustomBlur);
 
         this.populateCacheWithCommentAuthors();
 
-        this.editor.value(this.value)
-        this.focusIfNeeded(this.focused)
+        this.editor.value(this.value);
+        this.focusIfNeeded(this.focused);
     },
     watch: {
-        users: function (val, oldVal) {
+        users: function (val) {
             if (val.length > 0) {
                 this.selectedUserIndex = 0;
                 document.addEventListener("keydown", this.handleKeydown, true);
@@ -69,11 +69,11 @@ export default {
             }
         },
         focused: function (value) {
-            this.focusIfNeeded(value)
+            this.focusIfNeeded(value);
         },
         value: function (value) {
-            this.editor.value(value)
-            this.focusIfNeeded(true)
+            this.editor.value(value);
+            this.focusIfNeeded(true);
         }
     },
     data() {
@@ -247,12 +247,12 @@ export default {
             this.$nextTick(() => {
                 if (shouldFocus) {
                     this.editor.codemirror.focus();
-                    this.editor.codemirror.execCommand("goDocEnd")
+                    this.editor.codemirror.execCommand("goDocEnd");
                 }
-            })
+            });
         },
         emitCustomBlur: function (editor) {
-            this.$emit("blur", editor.getValue())
+            this.$emit("blur", editor.getValue());
         }
     },
 };

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -23,6 +23,9 @@ Vue.component("desktop-editor", () => import("./DesktopMarkdownEditor.vue"));
 /**
  * The component is a facade for external use.
  * It chooses which version of the editor to show
+ *
+ * The value passed via prop used as the value setter for the editor.
+ * When the user moves the focus from the editor, `blur` event with an updated value is sent
  */
 export default {
     props: {

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -1,8 +1,11 @@
 <template>
-    <mobile-editor v-if="isMobile">
-        <slot></slot>
-    </mobile-editor>
-    <desktop-editor v-else>
+    <mobile-editor
+        v-bind:value="value"
+        v-on:input="$emit('input', $event)"
+        v-on:blur="$emit('blur', $event)"
+        :focused="focused"
+        v-if="isMobile"></mobile-editor>
+    <desktop-editor :value="value" v-else>
         <slot></slot>
     </desktop-editor>
 </template>
@@ -15,6 +18,14 @@ Vue.component("mobile-editor", () => import("./MobileMarkdownEditor.vue"));
 Vue.component("desktop-editor", () => import("./DesktopMarkdownEditor.vue"));
 
 export default {
+    props: {
+        value: {
+            type: String
+        },
+        focused: {
+            type: Boolean
+        }
+    },
     methods: {
         isMobile,
     },

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -4,7 +4,7 @@
         v-on:input="$emit('input', $event)"
         v-on:blur="$emit('blur', $event)"
         :focused="focused"
-        v-if="isMobile"></mobile-editor>
+        v-if="isMobile()"></mobile-editor>
     <desktop-editor :value="value" v-else>
         <slot></slot>
     </desktop-editor>

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -1,17 +1,15 @@
 <template>
     <mobile-editor
         v-if="isMobile()"
-        v-bind:value="value"
-        v-on:input="$emit('input', $event)"
-        v-on:blur="$emit('blur', $event)"
+        :value="value"
         :focused="focused"
+        @blur="$emit('blur', $event)"
     ></mobile-editor>
     <desktop-editor
         v-else
-        v-bind:value="value"
-        v-on:input="$emit('input', $event)"
-        v-on:blur="$emit('blur', $event)"
+        :value="value"
         :focused="focused"
+        @blur="$emit('blur', $event)"
     ></desktop-editor>
 </template>
 

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -1,13 +1,18 @@
 <template>
     <mobile-editor
+        v-if="isMobile()"
         v-bind:value="value"
         v-on:input="$emit('input', $event)"
         v-on:blur="$emit('blur', $event)"
         :focused="focused"
-        v-if="isMobile()"></mobile-editor>
-    <desktop-editor :value="value" v-else>
-        <slot></slot>
-    </desktop-editor>
+    ></mobile-editor>
+    <desktop-editor
+        v-else
+        v-bind:value="value"
+        v-on:input="$emit('input', $event)"
+        v-on:blur="$emit('blur', $event)"
+        :focused="focused"
+    ></desktop-editor>
 </template>
 
 <script>
@@ -17,6 +22,10 @@ import { isMobile } from "../../common/utils";
 Vue.component("mobile-editor", () => import("./MobileMarkdownEditor.vue"));
 Vue.component("desktop-editor", () => import("./DesktopMarkdownEditor.vue"));
 
+/**
+ * The component is a facade for external use.
+ * It chooses which version of the editor to show
+ */
 export default {
     props: {
         value: {

--- a/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MarkdownEditor.vue
@@ -1,0 +1,22 @@
+<template>
+    <mobile-editor v-if="isMobile">
+        <slot></slot>
+    </mobile-editor>
+    <desktop-editor v-else>
+        <slot></slot>
+    </desktop-editor>
+</template>
+
+<script>
+import Vue from "vue";
+import { isMobile } from "../../common/utils";
+
+Vue.component("mobile-editor", () => import("./MobileMarkdownEditor.vue"));
+Vue.component("desktop-editor", () => import("./DesktopMarkdownEditor.vue"));
+
+export default {
+    methods: {
+        isMobile,
+    },
+};
+</script>

--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -5,9 +5,9 @@
             name="text"
             maxlength="20000"
             placeholder="Напишите ответ..."
-            v-bind:value="value"
-            v-on:blur="handleBlur"
             ref="textarea"
+            :value="value"
+            @blur="emitCustomBlur"
         >
         </textarea>
     </div>
@@ -32,7 +32,7 @@ export default {
         }
     },
     methods: {
-        handleBlur: function (event) {
+        emitCustomBlur: function () {
             this.$emit("blur", this.$refs["textarea"].value)
         },
         focusTextareaIfNeeded: function(shouldFocus) {

--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -1,8 +1,43 @@
 <template>
     <div class="comment-markdown-editor">
-        <slot></slot>
+        <textarea
+            required
+            name="text"
+            maxlength="20000"
+            placeholder="Напишите ответ..."
+            v-bind:value="value"
+            v-on:input="$emit('input', $event.target.value)"
+            v-on:blur="$emit('blur', $event)"
+            ref="textarea"
+        >
+        </textarea>
     </div>
 </template>
 
 <script>
+export default {
+    props: {
+        value: {
+            type: String
+        },
+        focused: {
+            type: Boolean
+        }
+    },
+    mounted: function() {
+            this.focusTextareaIfNeeded(this.focused)
+    },
+    watch: {
+        focused: function (value) {
+            this.focusTextareaIfNeeded(value)
+        }
+    },
+    methods: {
+        focusTextareaIfNeeded: function(shouldFocus) {
+            this.$nextTick(() => {
+                shouldFocus && this.$refs["textarea"].focus();
+            })
+        }
+    }
+}
 </script>

--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -6,8 +6,7 @@
             maxlength="20000"
             placeholder="Напишите ответ..."
             v-bind:value="value"
-            v-on:input="$emit('input', $event.target.value)"
-            v-on:blur="$emit('blur', $event)"
+            v-on:blur="handleBlur"
             ref="textarea"
         >
         </textarea>
@@ -33,6 +32,9 @@ export default {
         }
     },
     methods: {
+        handleBlur: function (event) {
+            this.$emit("blur", this.$refs["textarea"].value)
+        },
         focusTextareaIfNeeded: function(shouldFocus) {
             this.$nextTick(() => {
                 shouldFocus && this.$refs["textarea"].focus();

--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -1,0 +1,8 @@
+<template>
+    <div class="comment-markdown-editor">
+        <slot></slot>
+    </div>
+</template>
+
+<script>
+</script>

--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -24,21 +24,21 @@ export default {
         }
     },
     mounted: function() {
-            this.focusTextareaIfNeeded(this.focused)
+            this.focusTextareaIfNeeded(this.focused);
     },
     watch: {
         focused: function (value) {
-            this.focusTextareaIfNeeded(value)
+            this.focusTextareaIfNeeded(value);
         }
     },
     methods: {
         emitCustomBlur: function () {
-            this.$emit("blur", this.$refs["textarea"].value)
+            this.$emit("blur", this.$refs["textarea"].value);
         },
         focusTextareaIfNeeded: function(shouldFocus) {
             this.$nextTick(() => {
                 shouldFocus && this.$refs["textarea"].focus();
-            })
+            });
         }
     }
 }

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -10,7 +10,7 @@
 
             <div class="reply-form-body">
                 <comment-markdown-editor
-                    v-model="text"
+                    :value="text"
                     :focused="isFocused"
                     @blur="handleBlur"
                 >

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -12,7 +12,7 @@
                 <comment-markdown-editor
                     v-model="text"
                     :focused="isFocused"
-                    v-on:blur="isFocused = false"
+                    v-on:blur="handleBlur"
                 >
                 </comment-markdown-editor>
             </div>
@@ -89,56 +89,20 @@ export default {
             const newCommentEl = document.getElementById(`comment-${this.replyTo.commentId}`)
             if (replyForm.previousSibling !== newCommentEl) {
                 newCommentEl.after(replyForm)
-
-                // editor.focus()
-                // !isMobile() && editor.execCommand("goDocEnd")
-
                 replyForm.scrollIntoView({ behavior: "smooth", block: "center" })
             }
         }
     },
     methods: {
-        // appendMarkdownTextareaValue: function(value) {
-        //     const textarea = document.querySelector("#comment-reply-form textarea")
-        //     textarea.focus(); // on mobile
-        //     textarea.value = value;
-        //
-        //     const editor = this.getEditor()
-        //     if (editor && !isMobile()) {
-        //         editor.setValue(editor.getValue() + value);
-        //     }
-        // },
         saveDraft: function(commentId) {
             if (this.text.length > 0) {
                 this.drafts[commentId] = this.text;
             }
         },
-        // getEditor: function() {
-        //     if (!this.editor) {
-        //         const textarea = document.querySelector("#comment-reply-form textarea")
-        //
-        //         if (isMobile()) {
-        //             this.editor = textarea
-        //             textarea.focus(); // on mobile
-        //         } else {
-        //             if (!textarea.nextElementSibling) {
-        //                 console.error(`Couldn't find CodeMirror editor for ${textarea}`)
-        //                 return
-        //             }
-        //
-        //             const codeMirrorEditor = textarea.nextElementSibling.CodeMirror ||
-        //                 textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
-        //
-        //             if (codeMirrorEditor === undefined) {
-        //                 console.error(`Couldn't find CodeMirror editor for ${textarea}`)
-        //             }
-        //
-        //             this.editor = codeMirrorEditor
-        //         }
-        //     }
-        //
-        //     return this.editor
-        // }
+        handleBlur: function(textValue) {
+            this.isFocused = false
+            this.text = textValue
+        }
     }
 }
 

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -26,7 +26,7 @@
 
 <script>
 export default {
-    name: 'ReplyForm',
+    name: "ReplyForm",
     props: {
         // type { commentId: string, username: string, draftKey?: string }
         replyTo: {
@@ -51,7 +51,7 @@ export default {
     },
     computed: {
         avatarAlt: function() {
-            return `Аватар ${this.$props.username}`
+            return `Аватар ${this.$props.username}`;
         }
     },
     data: function () {
@@ -60,7 +60,7 @@ export default {
             editor: undefined,
             text: "",
             isFocused: false,
-        }
+        };
     },
     watch: {
         replyTo: function(newReplyTo, oldReplyTo) {
@@ -68,28 +68,28 @@ export default {
                 this.saveDraft(getDraftKey(oldReplyTo));
             }
 
-            const newDraftKey = getDraftKey(newReplyTo)
+            const newDraftKey = getDraftKey(newReplyTo);
             if (newDraftKey in this.drafts) {
-                this.text = this.drafts[newDraftKey]
+                this.text = this.drafts[newDraftKey];
             } else {
-                this.text = "@" + newReplyTo.username + ", "
+                this.text = "@" + newReplyTo.username + ", ";
             }
 
             this.replyTo = newReplyTo;
-            this.isFocused = true
+            this.isFocused = true;
         }
     },
     mounted: function() {
-        this.isFocused = true
+        this.isFocused = true;
     },
     updated: function() {
         if (this.replyTo !== null) {
             // move the reply form under the comment
-            const replyForm = document.getElementById("comment-reply-form")
-            const newCommentEl = document.getElementById(`comment-${this.replyTo.commentId}`)
+            const replyForm = document.getElementById("comment-reply-form");
+            const newCommentEl = document.getElementById(`comment-${this.replyTo.commentId}`);
             if (replyForm.previousSibling !== newCommentEl) {
-                newCommentEl.after(replyForm)
-                replyForm.scrollIntoView({ behavior: "smooth", block: "center" })
+                newCommentEl.after(replyForm);
+                replyForm.scrollIntoView({ behavior: "smooth", block: "center" });
             }
         }
     },
@@ -100,13 +100,13 @@ export default {
             }
         },
         handleBlur: function(textValue) {
-            this.isFocused = false
-            this.text = textValue
+            this.isFocused = false;
+            this.text = textValue;
         }
     }
 }
 
 function getDraftKey(replyTo) {
-    return replyTo?.draftKey || replyTo?.commentId
+    return replyTo?.draftKey || replyTo?.commentId;
 }
 </script>

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -12,7 +12,7 @@
                 <comment-markdown-editor
                     v-model="text"
                     :focused="isFocused"
-                    v-on:blur="handleBlur"
+                    @blur="handleBlur"
                 >
                 </comment-markdown-editor>
             </div>

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -1,29 +1,27 @@
 <template>
-    <div>
-        <form method="post" :action="createCommentUrl" class="form reply-form-form" id="comment-reply-form" v-if="replyTo !== null">
-            <input type="hidden" name="post_comment_order" :value="commentOrder">
-            <input type="hidden" name="reply_to_id" :value="replyTo.commentId">
+    <form method="post" :action="createCommentUrl" class="form reply-form-form" id="comment-reply-form" v-if="replyTo !== null">
+        <input type="hidden" name="post_comment_order" :value="commentOrder">
+        <input type="hidden" name="reply_to_id" :value="replyTo.commentId">
 
-            <div class="reply-form">
-                <div class="reply-form-avatar">
-                    <div class="avatar"><img :src="avatarUrl" :alt="avatarAlt" loading="lazy" /></div>
-                </div>
-
-                <div class="reply-form-body">
-                    <comment-markdown-editor>
-                        <textarea name="text" maxlength="20000" placeholder="Напишите ответ..." class="markdown-editor-invisible" required>
-                        </textarea>
-                    </comment-markdown-editor>
-                </div>
-
-                <div class="reply-form-button">
-                    <button type="submit" class="button button-small">Отправить</button>
-                </div>
+        <div class="reply-form">
+            <div class="reply-form-avatar">
+                <div class="avatar"><img :src="avatarUrl" :alt="avatarAlt" loading="lazy" /></div>
             </div>
-        </form>
 
-        <slot></slot>
-    </div>
+            <div class="reply-form-body">
+                <comment-markdown-editor
+                    v-model="text"
+                    :focused="isFocused"
+                    v-on:blur="isFocused = false"
+                >
+                </comment-markdown-editor>
+            </div>
+
+            <div class="reply-form-button">
+                <button type="submit" class="button button-small">Отправить</button>
+            </div>
+        </div>
+    </form>
 </template>
 
 <script>
@@ -59,86 +57,88 @@ export default {
     data: function () {
         return {
             drafts: {},
-            editor: undefined
+            editor: undefined,
+            text: "",
+            isFocused: false,
         }
     },
     watch: {
-        replyTo: async function(newReplyTo, oldReplyTo) {
-            this.replyTo = newReplyTo;
+        replyTo: function(newReplyTo, oldReplyTo) {
             if (oldReplyTo) {
                 this.saveDraft(getDraftKey(oldReplyTo));
             }
+
+            const newDraftKey = getDraftKey(newReplyTo)
+            if (newDraftKey in this.drafts) {
+                this.text = this.drafts[newDraftKey]
+            } else {
+                this.text = "@" + newReplyTo.username + ", "
+            }
+
+            this.replyTo = newReplyTo;
+            this.isFocused = true
         }
     },
+    mounted: function() {
+        this.isFocused = true
+    },
     updated: function() {
-        if (this.replyTo !== null && this.getEditor()) {
+        if (this.replyTo !== null) {
             // move the reply form under the comment
             const replyForm = document.getElementById("comment-reply-form")
             const newCommentEl = document.getElementById(`comment-${this.replyTo.commentId}`)
-            newCommentEl.after(replyForm)
-            const editor = this.getEditor()
-            const draftKey = getDraftKey(this.replyTo)
+            if (replyForm.previousSibling !== newCommentEl) {
+                newCommentEl.after(replyForm)
 
-            if (draftKey in this.drafts) {
-                const text = this.drafts[draftKey]
-                const textarea = replyForm.querySelector("textarea")
-                textarea.value = text
-                editor.setValue(text)
-            } else {
-                this.getEditor().setValue("")
-                // Add username to reply
-                const username = this.replyTo.username
-                if (username !== null && username !== "") {
-                    this.appendMarkdownTextareaValue("@" + username + ", ");
-                }
+                // editor.focus()
+                // !isMobile() && editor.execCommand("goDocEnd")
+
+                replyForm.scrollIntoView({ behavior: "smooth", block: "center" })
             }
-
-            editor.focus()
-            editor.execCommand("goDocEnd")
-
-            replyForm.scrollIntoView({behavior: "smooth", block: "center"})
         }
     },
     methods: {
-        appendMarkdownTextareaValue: function(value) {
-            const textarea = document.querySelector("#comment-reply-form textarea")
-            textarea.focus(); // on mobile
-            textarea.value = textarea.value + value;
-
-            const editor = this.getEditor()
-            if (editor) {
-                editor.setValue(editor.getValue() + value);
-            }
-        },
+        // appendMarkdownTextareaValue: function(value) {
+        //     const textarea = document.querySelector("#comment-reply-form textarea")
+        //     textarea.focus(); // on mobile
+        //     textarea.value = value;
+        //
+        //     const editor = this.getEditor()
+        //     if (editor && !isMobile()) {
+        //         editor.setValue(editor.getValue() + value);
+        //     }
+        // },
         saveDraft: function(commentId) {
-            const editor = this.getEditor()
-            const text = editor.getValue()
-            if (editor && text.length > 0) {
-                this.drafts[commentId] = editor.getValue();
+            if (this.text.length > 0) {
+                this.drafts[commentId] = this.text;
             }
         },
-        getEditor: function() {
-            if (!this.editor) {
-                const textarea = document.querySelector("#comment-reply-form textarea")
-
-                textarea.focus(); // on mobile
-                if (!textarea.nextElementSibling) {
-                    console.error(`Couldn't find CodeMirror editor for ${textarea}`)
-                    return
-                }
-
-                const codeMirrorEditor = textarea.nextElementSibling.CodeMirror ||
-                    textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
-
-                if (codeMirrorEditor === undefined) {
-                    console.error(`Couldn't find CodeMirror editor for ${textarea}`)
-                }
-
-                this.editor = codeMirrorEditor
-            }
-
-            return this.editor
-        }
+        // getEditor: function() {
+        //     if (!this.editor) {
+        //         const textarea = document.querySelector("#comment-reply-form textarea")
+        //
+        //         if (isMobile()) {
+        //             this.editor = textarea
+        //             textarea.focus(); // on mobile
+        //         } else {
+        //             if (!textarea.nextElementSibling) {
+        //                 console.error(`Couldn't find CodeMirror editor for ${textarea}`)
+        //                 return
+        //             }
+        //
+        //             const codeMirrorEditor = textarea.nextElementSibling.CodeMirror ||
+        //                 textarea.nextElementSibling.querySelector(".CodeMirror").CodeMirror;
+        //
+        //             if (codeMirrorEditor === undefined) {
+        //                 console.error(`Couldn't find CodeMirror editor for ${textarea}`)
+        //             }
+        //
+        //             this.editor = codeMirrorEditor
+        //         }
+        //     }
+        //
+        //     return this.editor
+        // }
     }
 }
 

--- a/frontend/static/js/main.js
+++ b/frontend/static/js/main.js
@@ -23,7 +23,7 @@ Vue.component("stripe-checkout-button", () => import("./components/StripeCheckou
 Vue.component("input-length-counter", () => import("./components/InputLengthCounter.vue"));
 Vue.component("friend-button", () => import("./components/FriendButton.vue"));
 Vue.component("comment-scroll-arrow", () => import("./components/CommentScrollArrow.vue"));
-Vue.component("comment-markdown-editor", () => import("./components/CommentMarkdownEditor.vue"));
+Vue.component("comment-markdown-editor", () => import("./components/MarkdownEditor/MarkdownEditor.vue"));
 Vue.component("v-select", vSelect);
 Vue.component("tag-select", () => import("./components/TagSelect.vue"));
 Vue.component("simple-select", () => import("./components/SimpleSelect.vue"));


### PR DESCRIPTION
## Что

Выделяет логику работы мобильного и десктопного редакторов в отдельные компоненты.

## Зачем

Мы хотим добавить загрузку картинок. Со старым подходом к логике становится сложно держать в голове задачу. Всё поведение хранится в одном компоненте и переключается с помощью `if (isMobile) {...}`, плюс `ReplyForm` лезет внутрь редактора и добавляет свою логику поверх.

## Как

`ReplyForm` использует фасад в виде `MarkdownEditor`, который в свою очередь решает, что ему рендерить `MobileMarkdownEditor` (простая textarea) или `DesktopMobileEditor` (полноценный маркдаун)