### PR TITLE
Правит прокрутку до поля ответов в iOS

### DIFF
--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -76,17 +76,6 @@
         margin-left: 0;
     }
 
-    @media only screen and (max-width : 570px) {
-        .reply-form {
-            margin-top: 20px;
-        }
-
-        .reply-form-avatar .avatar {
-            width: 20px;
-            height: 20px;
-        }
-    }
-
     .reply-form textarea {
         width: 100%;
         height: 80px;
@@ -120,6 +109,27 @@
     .reply-form .button {
         margin-top: 10px;
     }
+
+@media only screen and (max-width: 570px) {
+    .reply-form {
+        margin-top: 20px;
+    }
+
+    .reply-form-avatar .avatar {
+        width: 20px;
+        height: 20px;
+    }
+
+    .comment-form textarea,
+    .reply-form textarea {
+        /*
+        Caveat!
+        increase font size for textareas on small screens, to avoid mobile Safari zoom-in
+        https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/
+        */
+        font-size: 125%;
+    }
+}
 
 .thread {
 

--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -127,7 +127,7 @@
         increase font size for textareas on small screens, to avoid mobile Safari zoom-in
         https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/
         */
-        font-size: max(125%, 16px)
+        font-size: max(1.25rem, 16px);
     }
 }
 

--- a/frontend/static/css/components/comments.css
+++ b/frontend/static/css/components/comments.css
@@ -127,7 +127,7 @@
         increase font size for textareas on small screens, to avoid mobile Safari zoom-in
         https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/
         */
-        font-size: 125%;
+        font-size: max(125%, 16px)
     }
 }
 

--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -91,8 +91,15 @@ export default {
             const newCommentEl = document.getElementById(`comment-${this.replyTo.commentId}`);
             if (replyForm.previousSibling !== newCommentEl) {
                 newCommentEl.after(replyForm);
-                replyForm.scrollIntoView({ behavior: "smooth", block: "center" });
             }
+
+            // Caveat
+            // the scroll is delayed to ensure the on-screen keyboard on mobile devices has opened
+            // to avoid the behavior on Safari for iOS, when the keyboard moves the content up
+            // (see more, https://stackoverflow.com/questions/56351216/ios-safari-unwanted-scroll-when-keyboard-is-opened-and-body-scroll-is-disabled)
+            setTimeout(() => {
+                replyForm.scrollIntoView({ behavior: "smooth", block: "center" });
+            }, 50);
         }
     },
     methods: {


### PR DESCRIPTION
Делает две вещи:
- увеличивает шрифт до 16 пикселей в полях ответов на мобиле. Это позволяет избежать [призумливания на мобильных сафари](https://css-tricks.com/16px-or-larger-text-prevents-ios-form-zoom/)
- Откладывает прокрутку до поля ответа на 50мс. Это позволяет дождаться появления виртуальной клавиатуры и прокручивать уже имея ее на экране. Без задержки [клавиатура на iOS сдвигает сайт вверх](https://stackoverflow.com/questions/56351216/ios-safari-unwanted-scroll-when-keyboard-is-opened-and-body-scroll-is-disabled)