### PR TITLE
Убирает прокрутку к последнему полю ответа при уходе фокуса

### DIFF
--- a/frontend/static/js/components/ReplyForm.vue
+++ b/frontend/static/js/components/ReplyForm.vue
@@ -97,7 +97,7 @@ export default {
             // the scroll is delayed to ensure the on-screen keyboard on mobile devices has opened
             // to avoid the behavior on Safari for iOS, when the keyboard moves the content up
             // (see more, https://stackoverflow.com/questions/56351216/ios-safari-unwanted-scroll-when-keyboard-is-opened-and-body-scroll-is-disabled)
-            setTimeout(() => {
+            this.isFocused && setTimeout(() => {
                 replyForm.scrollIntoView({ behavior: "smooth", block: "center" });
             }, 50);
         }


### PR DESCRIPTION
## Что

Обратил внимание, что мы прокручиваем к последней форме ответа в момент, когда форма теряет фокус:


[](https://github.com/user-attachments/assets/f9ba58d0-97ab-421a-88f0-3df3a32a2431)

## Как

Проверяет, что флаг `isFocused` взведен прежде чем запланировать прокрутку:

[](https://github.com/user-attachments/assets/f727102f-7c91-437b-aba5-04acac2f9730)

