### PR TITLE
Перемещает фокус в редактор текста после загрузки картинки

### DIFF
--- a/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
+++ b/frontend/static/js/components/MarkdownEditor/MobileMarkdownEditor.vue
@@ -73,10 +73,12 @@ export default {
                             if (filename) {
                                 const urlMarkdown = settings.urlText.replace(settings.filenameTag, filename);
                                 textarea.value = replaceProgressTextOrAppend(textarea.value, settings.progressText, urlMarkdown);
+                                this.focusTextareaIfNeeded(true);
                             }
                         },
                         () => {
                             textarea.value = replaceProgressTextOrAppend(textarea.value, settings.progressText, settings.errorText);
+                            this.focusTextareaIfNeeded(true);
                         }
                     );
                 }

--- a/frontend/static/js/inline-attachment.js
+++ b/frontend/static/js/inline-attachment.js
@@ -400,7 +400,18 @@ export function isFileAllowed(file, settings) {
             if (isFileAllowed(file, this.settings)) {
                 result = true;
                 this.onFileInserted(file);
-                uploadFile(file, this.settings, this.onFileUploadResponse.bind(this), this.onFileUploadError.bind(this));
+                uploadFile(
+                    file,
+                    this.settings,
+                    (xhr) => {
+                        this.onFileUploadResponse.call(this, xhr);
+                        this.editor.codeMirror.focus();
+                    },
+                    (xhr) => {
+                        this.onFileUploadError.call(this, xhr);
+                        this.editor.codeMirror.focus();
+                    }
+                );
             }
         }
 


### PR DESCRIPTION
Обратил внимание, что все прошлые варианты загрузки возвращают фокус в поле ввода. Добавил, чтобы и после загрузки через кнопку фокус возвращался в поле. Для десктопа он возвращается в какое-то странное место, но это поведение аналогично тому, что есть и при драг-н-дропе 

[](https://github.com/user-attachments/assets/adb6a0aa-0c93-4f00-8930-402ffc1ee9bc)

