### PR TITLE
fix: use button in user-tag instead of a

### DIFF
--- a/frontend/static/css/components/profile.css
+++ b/frontend/static/css/components/profile.css
@@ -353,6 +353,8 @@
                 font-size: 110%;
                 font-weight: 300;
                 padding: 7px 20px;
+                color: inherit;
+                background: none;
                 border: var(--button-hover-border);
                 margin-right: 20px;
                 margin-bottom: 20px;

--- a/frontend/static/js/components/UserTag.vue
+++ b/frontend/static/js/components/UserTag.vue
@@ -1,12 +1,12 @@
 <template>
-    <a
-        :href="url"
+    <button
+        type="button"
         :class="{ 'user-tag-active': isActive }"
         :style="{ 'background-color': isActive ? tagColor : null }"
         @click.prevent="toggle"
     >
         {{ tagName }}
-    </a>
+    </button>
 </template>
 
 <script>


### PR DESCRIPTION
Сделал кнопку вместо ссылки. Причина стандартная - ссылкой должны быть только ссылки. Именно кнопкой а не образным дивом чтобы сохранить доступность.

Closes #1151
