### PR TITLE
feat: allow uploading webp images

### DIFF
--- a/frontend/static/js/common/markdown-editor.js
+++ b/frontend/static/js/common/markdown-editor.js
@@ -57,6 +57,7 @@ export const imageUploadOptions = {
     allowedTypes: [
         "image/jpeg",
         "image/png",
+        "image/webp",
         "image/jpg",
         "image/gif",
         "video/mp4",


### PR DESCRIPTION
Включил возможность добавлять webp-изображения на фронте, [по запросу](https://vas3k.club/post/26312/#comment-1877bfa7-331c-4029-9d49-03dd809f633d) из поста про [Хактоберфест](https://vas3k.club/post/26312/)

На бэке уже работает (конвертирует в jpg), оставалось разрешить на фронте