### PR TITLE
Закреплённые комменты ломали `CommentScrollArrow`

### DIFF
--- a/frontend/html/comments/types/bold.html
+++ b/frontend/html/comments/types/bold.html
@@ -1,8 +1,8 @@
 {% load text_filters %}
 {% load posts %}
 {% load comments %}
-<div id="comment-{{ comment.id }}">
-    <div class="block comment comment-layout-block {% if comment.metadata.badges %}comment-is-badged{% endif %}">
+<div class="block-comments-list">
+    <div class="block {% if comment.created_at > post_last_view_at %}comment-is-new{% endif %} comment comment-layout-block {% if comment.metadata.badges %}comment-is-badged{% endif %}" id="comment-{{ comment.id }}">
         <div class="comment-side">
             <a class="avatar comment-side-avatar" href="{% url "profile" comment.author.slug %}">
                 <img src="{{ comment.author.get_avatar }}" alt="Аватар {{ comment.author.full_name }}" loading="lazy" />
@@ -96,12 +96,14 @@
         </div>
     </div>
 
-    {% if replies %}
-        <div class="replies replies-indent-normal">
-            {% for reply_tree in replies %}
-                {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
-            {% endfor %}
-        </div>
-        <div class="clearfix20"></div>
-    {% endif %}
+    <div class="comment-replies thread-collapse-toggle">
+        {% if replies %}
+            <div class="replies replies-indent-normal">
+                {% for reply_tree in replies %}
+                    {% include "comments/types/reply.html" with comment=reply_tree.comment reply_to=reply_tree.comment replies=reply_tree.replies %}
+                {% endfor %}
+            </div>
+            <div class="clearfix20"></div>
+        {% endif %}
+    </div>
 </div>

--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -92,6 +92,10 @@ export default {
                      ".battle-comments-list .comment-replies > .replies > .reply.comment-is-new",
                      // Новые реплаи на втором уровне бэтлов
                      ".battle-comments-list .comment-replies > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
+                     // Новые реплаи к запиненым комментам (bold)
+                     ".block-comments-list .comment-replies > .replies > .reply.comment-is-new",
+                     // Новые реплаи на втором уровне запиненных комментов (bold)
+                     ".block-comments-list .comment-replies > .replies > .reply:not(.comment-is-new) > .reply-replies >.replies > .reply.comment-is-new",
                  ].join()
              );
 


### PR DESCRIPTION
Опять просьбы трудящихся (когда же они уже успокоятся?)
https://vas3k.club/post/26312/#comment-5532fd68-5cd6-4583-8017-e741315aa244

Проблема аналогичная как с батлами, элемент с `class=comment` не получал атрибута id и это ломало метод листания комментов. Решил по аналогии с батлами + добавил в `querySelector` с поиском новых комментов в том числе ответы на запиненные комменты. По аналогии с батлами, изменения затронули исключительно запиненные комменты, всё должно быть ровно. 

p.s. так же вастрикан просил поменять фон закреплённого коммента в светлой теме, типа его не видно, но это уже не ко мне. чукча не дизайнер, чукча баголеп. 

В ЛИСЕ ПРОВЕРИЛ!!!