### PR TITLE
Use <button> tag for the <comment-scroll-arrow> component

### DIFF
--- a/frontend/static/js/components/CommentScrollArrow.vue
+++ b/frontend/static/js/components/CommentScrollArrow.vue
@@ -1,12 +1,11 @@
 <template>
-    <span
+    <button
         class="comment-scroll-arrow"
         :class="{
             'arrow-up': arrowDirection === 'Up'
         }"
         @click.prevent="onArrowClickHandler"
-    >
-    </span>
+    ></button>
 </template>
 
 <script>


### PR DESCRIPTION
Поменял тег для кнопки `comment-scroll-arrow` со `span` на `button`.
<img width="84" alt="Screenshot 2024-11-18 at 04 12 54" src="https://github.com/user-attachments/assets/aca379bd-36f6-4e09-975f-32a298fccf26">


Это нужно для:
- семантики
- возможности сфокусироваться на кнопке через tab
- корректной работы расширения [Vimium](https://chromewebstore.google.com/detail/vimium/dbepggeogbaibhgnhhndojpepiihcmeb?hl=en)

[Запрос на фикс](https://vas3k.club/post/26312/#comment-f8843113-260a-4a9d-a985-30468f0f8518) в треде "Объявляется внеочередной сбор идей и фич для Клуба"