### PR TITLE
fix(api): prevent users from adding themselves as friends

### DIFF
--- a/users/models/friends.py
+++ b/users/models/friends.py
@@ -17,9 +17,7 @@ class Friend(models.Model):
 
     class Meta:
         db_table = "friends"
-        constraints = [
-            models.UniqueConstraint(fields=["user_from", "user_to"], name="unique_friendship")
-        ]
+        unique_together = [["user_from", "user_to"]]
 
     @classmethod
     def add_friend(cls, user_from, user_to):

--- a/users/models/friends.py
+++ b/users/models/friends.py
@@ -17,7 +17,9 @@ class Friend(models.Model):
 
     class Meta:
         db_table = "friends"
-        unique_together = [["user_from", "user_to"]]
+        constraints = [
+            models.UniqueConstraint(fields=["user_from", "user_to"], name="unique_friendship")
+        ]
 
     @classmethod
     def add_friend(cls, user_from, user_to):

--- a/users/views/friends.py
+++ b/users/views/friends.py
@@ -19,7 +19,7 @@ def api_friend(request, user_slug):
     user_to = get_object_or_404(User, slug=user_slug)
     user_from = request.me
 
-    if request.me == user_to:
+    if user_from == user_to:
         raise ApiException(title="You can't add yourself as a friend")
 
     if request.method == HTTPMethod.GET:

--- a/users/views/friends.py
+++ b/users/views/friends.py
@@ -1,22 +1,29 @@
-from django.http import Http404, HttpResponseForbidden
+from http import HTTPMethod
+
+from django.http import Http404
 from django.shortcuts import get_object_or_404, render, redirect
 from django.conf import settings
 from django.views.decorators.http import require_http_methods
 
 from authn.decorators.auth import require_auth
 from authn.decorators.api import api
+from club.exceptions import ApiException
 from common.pagination import paginate
 from users.models.friends import Friend
 from users.models.user import User
 
 
 @api(require_auth=True)
-@require_http_methods(["GET", "POST"])
+@require_http_methods([HTTPMethod.GET, HTTPMethod.POST])
 def api_friend(request, user_slug):
     user_to = get_object_or_404(User, slug=user_slug)
+    user_from = request.me
 
-    if request.method == "GET":
-        friend = Friend.user_friends(request.me).filter(user_to=user_to).first()
+    if request.me == user_to:
+        raise ApiException(title="You can't add yourself as a friend")
+
+    if request.method == HTTPMethod.GET:
+        friend = Friend.user_friends(user_from).filter(user_to=user_to).first()
         if not friend:
             raise Http404()
 
@@ -24,15 +31,15 @@ def api_friend(request, user_slug):
             "friend": friend.to_dict()
         }
 
-    if request.method == "POST":
+    if request.method == HTTPMethod.POST:
         friend, is_created = Friend.add_friend(
-            user_from=request.me,
+            user_from=user_from,
             user_to=user_to,
         )
 
         if not is_created:
             Friend.delete_friend(
-                user_from=request.me,
+                user_from=user_from,
                 user_to=user_to,
             )
 


### PR DESCRIPTION
В api_friend добавлена проверка, запрещающая пользователям отправлять запросы на добавление в друзья самим себе.  
Ранее конечная точка разрешала такие запросы, что приводило к недействительным записям в таблице друзей.  
Теперь, если `user_from == user_to`, будет поднят соответствующий ApiException с ответом 400.

Fixes: https://github.com/vas3k/vas3k.club/issues/1306