### PR TITLE
Fix unmute functionality when max mute limit reached

### DIFF
--- a/users/views/muted.py
+++ b/users/views/muted.py
@@ -37,7 +37,14 @@ def toggle_mute(request, user_slug):
             })
 
     # else — process POST
-    if total_user_muted_count > settings.MAX_MUTE_COUNT:
+    # Check if user is already muted to determine if this is a mute or unmute operation
+    is_already_muted = UserMuted.is_muted(
+        user_from=request.me,
+        user_to=user_to,
+    )
+
+    # Only check mute limit when trying to create a new mute
+    if not is_already_muted and total_user_muted_count >= settings.MAX_MUTE_COUNT:
         raise AccessDenied(
             title="Вы замьютили слишком много людей",
             message="Рекомендуем притормозить и подумать о будущем..."


### PR DESCRIPTION
## Summary
- Fix issue where users at max mute limit couldn't unmute anyone
- Move mute limit validation to only apply when creating new mutes

## Problem
When a user reached the maximum mute limit (20 users), they were unable to unmute anyone because the validation check happened before determining whether the action was a mute or unmute operation.

## Solution
- Check if target user is already muted before applying limit validation
- Only prevent new mutes when at the limit, allow unmuting existing mutes
- Change comparison from `>` to `>=` for more accurate limit checking

## Test plan
- [ ] User at max mute limit can successfully unmute existing muted users
- [ ] User at max mute limit still cannot mute new users
- [ ] Mute limit validation works correctly for users below the limit
- [ ] Я наконец-то смогу смотреть не половину мемов, а все мемы. Мемы мои мемы, мемасики...