### PR TITLE
feat: give mass achievements by urls

### DIFF
--- a/common/regexp.py
+++ b/common/regexp.py
@@ -1,6 +1,7 @@
 import re
 
 USERNAME_RE = re.compile(r"(?:\s|\n|^)@([A-Za-z0-9_-]{3,})")
+USER_URL_RE = re.compile(r"^https?://[^/]+/user/([A-Za-z0-9_-]+)")
 IMAGE_RE = re.compile(r"https?://[^\s/$.?#].[^\s]*\.(?:jpg|jpeg|gif|png)")
 VIDEO_RE = re.compile(r"https?://[^\s/$.?#].[^\s]*\.(?:mov|mp4)")
 YOUTUBE_RE = re.compile(


### PR DESCRIPTION
Изменения:
1. Теперь разных пользователей надо вводить через перенос строки или пробел,
2. Можно вводить слаги как раньше, а можно вводить ссылку на профиль.

<img width="1920" height="1200" alt="скриншот админки" src="https://github.com/user-attachments/assets/3018d7d2-d842-4c2e-9604-c4b96c6dfda4" />

Это потому что мне проще всего выдавать массовые ачивки, копируя ссылку с профиля или из результата команды /whois:

<img width="590" height="261" alt="скриншот бота" src="https://github.com/user-attachments/assets/3735493c-0e60-4b1b-a553-7f829c70a7bd" />

Локально проверил.