### PR TITLE
fixed upvote button overlap with post images

### DIFF
--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -155,7 +155,7 @@
 .post-type-post .upvote:not(.upvote-disabled) {
     float: left;
     position: sticky;
-    margin-left: -110px;
+    margin-left: -125px;
     margin-top: 30px;
 }
 


### PR DESCRIPTION
Что сделал: чуть подвинул кнопку для голосования за статью. Она часто налазит на изображения в статье.

До:
<img width="877" height="717" alt="до" src="https://github.com/user-attachments/assets/99f30fcc-d8ce-4145-9aca-063a067a2699" />
После:
<img width="900" height="721" alt="после" src="https://github.com/user-attachments/assets/377959c9-08c4-403d-9b66-16115c451da0" />
