### PR TITLE
fix: prevent favicon wrapping

### DIFF
--- a/frontend/static/css/components/posts.css
+++ b/frontend/static/css/components/posts.css
@@ -301,6 +301,7 @@
 
 .text-body a {
     font-weight: 600;
+    white-space: nowrap;
 }
 
 .text-body a[target="_blank"] {


### PR DESCRIPTION
### Before:

<img width="1570" height="320" alt="Screenshot 2026-04-24 at 14 12 20" src="https://github.com/user-attachments/assets/b571f043-50d0-4da6-bd05-5fd26629ef31" />

### After:

<img width="1574" height="322" alt="Screenshot 2026-04-24 at 14 12 14" src="https://github.com/user-attachments/assets/2e330003-4e85-4fc6-86eb-4c9904605c58" />
