### PR TITLE
fix: raw template tag in achievement page title

### DIFF
--- a/frontend/html/achievements/show_achievement.html
+++ b/frontend/html/achievements/show_achievement.html
@@ -1,5 +1,5 @@
-{% extends "layout.html" %} {% load static %} {% load users %} {% load text_filters %} {% block title %} Ачивка «{{
-achievement.name }}» — {{ block.super }} {% endblock %} {% block og_tags %}
+{% extends "layout.html" %} {% load static %} {% load users %} {% load text_filters %}
+{% block title %} Ачивка «{{ achievement.name }}» — {{ block.super }} {% endblock %} {% block og_tags %}
 <meta property="og:title" content="Ачивка «{{ achievement.name }}» — {{ settings.APP_NAME }}" />
 <meta property="og:site_name" content="{{ settings.APP_NAME }}" />
 <meta property="og:url" content="{{ settings.APP_HOST }}" />


### PR DESCRIPTION
## Баг

На странице ачивки (например, `/achievements/vas3k_camp_2026/`) тайтл вкладки показывает сырой тег:

> Ачивка «{{ achievement.name }}» — Вастрик.Клуб 🤘✖️👩‍💻

## Причина

В 995d96aa шаблон прогнали через Prettier, и он разорвал `{{ achievement.name }}` в `{% block title %}` переносом строки. Лексер Django не матчит теги через перенос строки, поэтому кусок ушёл в вывод как обычный текст.

## Фикс

Собрал тег обратно в одну строку. Проверил локально в docker: тайтл снова «Ачивка «Вастрик 🔥 Кэмп 2026» — Вастрик.Клуб 🤘✖️👩‍💻». Остальные шаблоны проверил на такие же разрывы — чисто.

⚠️ Prettier не знает про Django-теги — гонять его по frontend/html опасно.
