### PR TITLE
Fix FieldError in GET /user/<slug>/badges.json (#1476)

### DIFF
--- a/users/api.py
+++ b/users/api.py
@@ -68,7 +68,7 @@ def api_profile_achievements(request, user_slug):
 @api(require_auth=True)
 def api_profile_badges(request, user_slug):
     user = api_profile_user(request, user_slug)
-    user_badges = UserBadge.objects.filter(user=user).select_related("badge", "from_user")
+    user_badges = UserBadge.objects.filter(to_user=user).select_related("badge", "from_user")
     return JsonResponse({"user_badges": [ub.to_dict() for ub in user_badges]})
 
 


### PR DESCRIPTION
## Проблема

Эндпоинт `GET /user/<slug>/badges.json` падает с `FieldError` для **любого** пользователя (issue #1476):

```
Cannot resolve keyword 'user' into field. Choices are: badge, badge_id,
comment, comment_id, created_at, from_user, from_user_id, id, note, post,
post_id, to_user, to_user_id
```

## Причина

В `users/api.py` (`api_profile_badges`) фильтр обращается к полю `user`, которого у модели `UserBadge` нет — есть только `from_user` (кто выдал) и `to_user` (кому). Соседние ручки (`api_profile_tags`, `api_profile_achievements`) работают, потому что у `UserTag`/`UserAchievement` поле `user` действительно есть.

## Фикс

Фильтрация по `to_user=user` — бейджи, выданные этому пользователю. Это совпадает с семантикой ручки и с уже существующим аксессором `UserBadge.user_badges()` в `badges/models.py`, который использует ровно `filter(to_user=user)`.

```diff
- user_badges = UserBadge.objects.filter(user=user).select_related("badge", "from_user")
+ user_badges = UserBadge.objects.filter(to_user=user).select_related("badge", "from_user")
```

Fixes #1476