### PR TITLE
Fix badges.json 500 on any user with badges: guard null post/comment in to_dict

### DIFF
--- a/badges/models.py
+++ b/badges/models.py
@@ -158,9 +158,9 @@ class UserBadge(models.Model):
     def to_dict(self):
         return {
             "badge": self.badge.to_dict(),
-            "from_user": self.from_user.to_dict(),
+            "from_user": self.from_user.to_dict() if self.from_user else None,
             "created_at": self.created_at.isoformat(),
-            "post": {"id": self.post.id},
-            "comment": {"id": self.comment.id},
+            "post": {"id": self.post.id} if self.post else None,
+            "comment": {"id": self.comment.id} if self.comment else None,
             "note": self.note,
         }

--- a/badges/tests/test_badges.py
+++ b/badges/tests/test_badges.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from badges.models import Badge, UserBadge
 from club.exceptions import BadRequest, ContentDuplicated, InsufficientFunds
+from comments.models import Comment
 from posts.models.post import Post
 from users.models.user import User
 
@@ -97,3 +98,39 @@ class TestUserBadgeBusinessLogic(TestCase):
                 to_user=self.to_user,
                 post=self.post,
             )
+
+    def test_to_dict_handles_null_post_from_comment_badge(self):
+        comment_author = _create_user("badge_comment_author")
+        post = Post.objects.create(
+            slug="badge-comment-post",
+            type=Post.TYPE_POST,
+            title="Badge Comment Post",
+            text="Text",
+            author=comment_author,
+            visibility=Post.VISIBILITY_EVERYWHERE,
+            metadata={},
+        )
+        comment = Comment.objects.create(post=post, author=comment_author, text="Nice")
+
+        user_badge = UserBadge.create_user_badge(
+            badge=self.badge,
+            from_user=self.from_user,
+            to_user=comment_author,
+            comment=comment,
+        )
+
+        data = user_badge.to_dict()
+        self.assertIsNone(data["post"])
+        self.assertEqual(data["comment"], {"id": comment.id})
+
+    def test_to_dict_handles_null_comment_from_post_badge(self):
+        user_badge = UserBadge.create_user_badge(
+            badge=self.badge,
+            from_user=self.from_user,
+            to_user=self.to_user,
+            post=self.post,
+        )
+
+        data = user_badge.to_dict()
+        self.assertIsNone(data["comment"])
+        self.assertEqual(data["post"], {"id": self.post.id})


### PR DESCRIPTION
## Проблема

После фикса `FieldError` (#1476) эндпоинт `GET /user/<slug>/badges.json` всё ещё падает с 500 для **любого пользователя, у которого есть хотя бы один бейдж**:

```
AttributeError: 'NoneType' object has no attribute 'id'
```

200 сейчас возвращается только для юзеров с нулём бейджей — потому и не заметили сразу.

## Причина

У каждого `UserBadge` заполнено ровно одно из `post`/`comment`:
- `create_badge_for_post` создаёт бейдж с `comment=None` (`badges/views.py`)
- `create_badge_for_comment` — с `post=None`

А `from_user` вообще nullable (`on_delete=SET_NULL`).

При этом `UserBadge.to_dict()` дёргал `self.post.id`, `self.comment.id` и `self.from_user.to_dict()` безусловно.

## Фикс

Защита всех трёх nullable-связей + регрессионные тесты на оба случая (бейдж за пост → `comment=None`; бейдж за коммент → `post=None`).

```diff
-            "from_user": self.from_user.to_dict(),
-            "post": {"id": self.post.id},
-            "comment": {"id": self.comment.id},
+            "from_user": self.from_user.to_dict() if self.from_user else None,
+            "post": {"id": self.post.id} if self.post else None,
+            "comment": {"id": self.comment.id} if self.comment else None,
```

Relates to #1476. Тесты запускаются в CI (локально не гонял — нужен postgres).