### PR TITLE
Preserve type/ordering when searching from the topbar (#1206)

### DIFF
--- a/frontend/html/common/menu-full.html
+++ b/frontend/html/common/menu-full.html
@@ -21,6 +21,8 @@
     {% if me and me.is_member %}
         <form action="{% url "search" %}" class="menu-search">
             <input type="text" name="q" minlength="3" maxlength="200" class="menu-search-input" id="menu-search-input" value="{{ query|default:'' }}" placeholder="Поиск" enterkeyhint="search">
+            {% if type %}<input type="hidden" name="type" value="{{ type }}">{% endif %}
+            {% if ordering %}<input type="hidden" name="ordering" value="{{ ordering }}">{% endif %}
             <label for="menu-search-input" class="menu-search-label {% if query %}menu-search-label-is-active{% endif %}" id="menu-search-label"><i class="fas fa-search"></i></label>
             <input type="submit" value="&rarr;" style="position: absolute; top: 0; left: -9999px;">
         </form>

--- a/search/tests/test_search.py
+++ b/search/tests/test_search.py
@@ -428,6 +428,17 @@ class SearchViewsTests(TestCase):
 
         self.assertIn('<input type="hidden" name="type" value="post">', content)
 
+    def test_topbar_search_form_keeps_type_and_ordering(self):
+        response = self.search("домен", content_type="post", ordering="-upvotes")
+        content = response.content.decode()
+
+        # the topbar form (menu-full.html) must carry type and ordering so that
+        # changing the query does not drop the active filters (issue #1206).
+        # the hidden ordering input is unique to the topbar form — the search.html
+        # form uses a <select name="ordering"> instead.
+        self.assertIn('<input type="hidden" name="ordering" value="-upvotes">', content)
+        self.assertIn('<input type="hidden" name="type" value="post">', content)
+
     def test_type_post_excludes_intro_posts(self):
         intro = self.create_post(
             slug="intro_hidden",


### PR DESCRIPTION
## Проблема

При выбранном `type` или `ordering` изменение поисковой квери через топбар сбрасывает `type` и `ordering` (issue #1206).

## Причина

Форма поиска в топбаре (`frontend/html/common/menu-full.html`) отправляла только `q`. Форма на самой странице поиска (`search.html`) уже сохраняет фильтры — через скрытый `<input name="type">` и `<select name="ordering">` — а топбар нет.

## Фикс

Тот же паттерн для топбар-формы: скрытые инпуты `type`/`ordering`, обёрнутые в `{% if %}`, чтобы на обычных страницах (где этих переменных в контексте нет) ничего лишнего не рендерилось.

```diff
             <input type="text" name="q" ... value="{{ query|default:'' }}" ...>
+            {% if type %}<input type="hidden" name="type" value="{{ type }}">{% endif %}
+            {% if ordering %}<input type="hidden" name="ordering" value="{{ ordering }}">{% endif %}
```

## Тест

Добавлен `test_topbar_search_form_keeps_type_and_ordering`: проверяет, что в ответе поиска топбар-форма содержит оба скрытых инпута. Скрытый `name="ordering"` уникален именно для топбара (в `search.html` это `<select>`), поэтому ассерт покрывает конкретно этот фикс.

Fixes #1206