### PR TITLE
Fix duplicate search results across paginated pages (#1213)

### DIFF
--- a/search/tests/test_search.py
+++ b/search/tests/test_search.py
@@ -428,6 +428,40 @@ class SearchViewsTests(TestCase):
 
         self.assertIn('<input type="hidden" name="type" value="post">', content)
 
+    def test_pagination_does_not_duplicate_results_across_pages(self):
+        # create enough posts with an identical rank/upvotes tie to span two
+        # pages (SEARCH_PAGE_SIZE == 25). Without a unique tiebreaker in the
+        # ORDER BY, Postgres may return the same row on both pages (issue #1213).
+        for i in range(30):
+            self.create_post(
+                slug="dup_page_{}".format(i),
+                title="PAGINATION DUP TOKEN {}".format(i),
+                text="PAGINATION DUP TOKEN",
+                author=self.new_user,
+                upvotes=5,
+            )
+
+        page1 = self.client.get(
+            reverse("search"),
+            data={"q": "PAGINATION DUP TOKEN", "ordering": "-upvotes", "page": 1},
+        )
+        page2 = self.client.get(
+            reverse("search"),
+            data={"q": "PAGINATION DUP TOKEN", "ordering": "-upvotes", "page": 2},
+        )
+
+        page1_ids = [r.id for r in page1.context["results"]]
+        page2_ids = [r.id for r in page2.context["results"]]
+
+        # both pages must contain results and must not overlap
+        self.assertTrue(page1_ids)
+        self.assertTrue(page2_ids)
+        self.assertEqual(
+            set(page1_ids) & set(page2_ids),
+            set(),
+            "search results duplicated across paginated pages",
+        )
+
     def test_type_post_excludes_intro_posts(self):
         intro = self.create_post(
             slug="intro_hidden",

--- a/search/views.py
+++ b/search/views.py
@@ -39,7 +39,11 @@ def search(request):
     if ordering not in ALLOWED_ORDERING:
         ordering = "-rank"
 
-    results = results.order_by(ordering)
+    # append the unique primary key as a tiebreaker so rows with equal
+    # ordering values keep a stable, deterministic order across paginated
+    # LIMIT/OFFSET queries — otherwise Postgres may repeat or skip rows
+    # between pages (issue #1213).
+    results = results.order_by(ordering, "id")
 
     return render(request, "search.html", {
         "type": content_type,


### PR DESCRIPTION
## Проблема

При переходе на следующую страницу выдачи поиска часть результатов дублируется с предыдущей страницы (issue #1213). Пример из ишью: `/search/?q=Computer+Science` — последние вхождения первой страницы повторяются в начале второй.

## Причина

В `search/views.py` перед пагинацией вызывается `results.order_by(ordering)` без уникального тайбрейкера. При равных значениях сортировки (`-rank`, `-upvotes`, `-created_at`, `created_at` — все допускают ties) Postgres не гарантирует стабильный порядок между `LIMIT/OFFSET`-запросами. В итоге одна и та же строка может попасть на обе страницы, а другая — потеряться.

## Фикс

Добавляю уникальный первичный ключ (`id`) вторым ключом сортировки — порядок становится детерминированным:

```diff
-    results = results.order_by(ordering)
+    results = results.order_by(ordering, "id")
```

## Тест

`test_pagination_does_not_duplicate_results_across_pages`: создаёт 30 постов с одинаковым `upvotes` (гарантированные ties), запрашивает страницы 1 и 2 при `ordering=-upvotes` (page_size = 25) и проверяет, что множества id страниц не пересекаются.

Fixes #1213